### PR TITLE
Phase 2.5b: generic schema-driven projection (closes #7)

### DIFF
--- a/.github/skills/project-xml/SKILL.md
+++ b/.github/skills/project-xml/SKILL.md
@@ -175,6 +175,27 @@ looks the document up by the second positional CLI argument.
 *   **Bump `<project schema_version="...">`** whenever you change the
     structure of `Project.xml` in a way that existing templates or
     `tools/render_doc.py` could not consume unchanged.
+*   **Any change to `tools/project.xsd` requires a matching update
+    to [doc/Schema_Reference.md](../../../doc/Schema_Reference.md)
+    in the same commit.** This applies to every kind of XSD edit:
+    new / removed / renamed elements or attributes, changed
+    cardinality, tightened or loosened restrictions, new
+    `<xs:appinfo>` UI-hint vocabulary, schema_version bumps. The
+    schema reference is the human-facing contract; if it drifts
+    from the XSD, downstream edits made against the reference
+    will silently produce invalid XML. (See also the callout at
+    the top of this file.)
+*   **Update [README.md](../../../README.md) before pushing any
+    commit that changes user-visible status or functionality.**
+    The README's *Status* table (which phase / sub-phase is
+    delivered vs. in flight) and *VS Code extension* / *CLI
+    tooling* feature lists are the project's public face. Whenever
+    a phase or slice ships a new surface (a new tree node, a new
+    command, a new setting, a new `Finding.code`, a new schema-
+    version bump, a phase status change), refresh the README in
+    the same branch and verify the doc-link section still points
+    at the right files. README cleanup is a precondition for
+    `git push`, not a follow-up.
 
 ## Schema and Renderer Data Surface
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree provider auto-projects any `<ui:treeNode/>`-annotated payload via `buildGenericPayloadNodes`; lens provider drives its `(element, idAttr)` selectors from `ui:lens` hints) |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | ✅ Done — Python `_ui_hints_index` + `_nodes` over JSON-RPC; TS shim typed; tree provider auto-projects any `<ui:treeNode/>` payload, lens provider scans schema-declared lens kinds, lint diagnostics resolve schema-declared id tokens. Adding a new payload requires zero TypeScript edits. |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree provider auto-projects any `<ui:treeNode/>`-annotated payload via `buildGenericPayloadNodes`; lens provider + locator rewrite still pending) |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree provider auto-projects any `<ui:treeNode/>`-annotated payload via `buildGenericPayloadNodes`; lens provider drives its `(element, idAttr)` selectors from `ui:lens` hints) |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree / lens / locator rewrite still pending) |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree provider auto-projects any `<ui:treeNode/>`-annotated payload via `buildGenericPayloadNodes`; lens provider + locator rewrite still pending) |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python side: `xs:appinfo` published in XSD, `ui_hints_index` surfaced over JSON-RPC) |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python side complete; TS sidecar now exposes typed `uiHintsIndex()` + embedded `_ui_hints_index` on `parse_to_json`; tree / lens / locator rewrite pending) |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python side complete; TS sidecar now exposes typed `uiHintsIndex()` + embedded `_ui_hints_index` on `parse_to_json`; tree / lens / locator rewrite pending) |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python: `_ui_hints_index` + generic `_nodes` index emitted by `parse_to_json`; TS: typed `uiHintsIndex()` + `ParsedNode`; tree / lens / locator rewrite still pending) |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ phased VS Code extension roadmap).
 | 1     | Read-only VS Code extension: tree view, lint diagnostics, Reveal in XML. | ✅ Complete |
 | 2     | Code Lenses + Render & Preview. | ✅ Complete |
 | 2.5   | Schema-driven retrofit: `list_documents` discovery, dynamic `Render <Doc>` commands, `Finding.code` linter contract, `ui:*` per-element hints, coverage status badges, `<plan>` acceptance proof. | ✅ Complete |
-| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | ⏳ Not started |
+| 2.5b  | Generic schema-driven projection: full `xs:appinfo` vocabulary, generic `ParsedNode`, tree / lens / locator rewrite. | 🚧 In progress (Python side: `xs:appinfo` published in XSD, `ui_hints_index` surfaced over JSON-RPC) |
 | 2.5c  | Payload-agnostic Quick Fix table keyed on `Finding.code`. | ⏳ Not started |
 | 3     | Form webviews for HLRs / LLRs. | ⏳ Not started |
 | 4     | SDD/STP/Test forms + Walkthrough. | ⏳ Not started |

--- a/doc/Project.xml
+++ b/doc/Project.xml
@@ -7,7 +7,7 @@
   payload sections (sdd, stp, hlrs, llrs, tests) as the project takes
   shape, then regenerate the markdown specs with `render_doc.py`.
 -->
-<project name="TraceR" short_name="TR" schema_version="1.3"
+<project name="TraceR" short_name="TR" schema_version="1.4"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../tools/project.xsd">
   <metadata>

--- a/doc/Schema_Reference.md
+++ b/doc/Schema_Reference.md
@@ -1242,4 +1242,22 @@ The vocabulary's element and attribute names listed in §16.1 are
 new `ui:field` `kind=` values may be added; existing values will not
 change meaning.
 
+### 16.5 Consumer status (Phase 2.5b)
+
+The VS Code extension consumes the vocabulary at four seams:
+
+| Seam | Hint key | Slice |
+|---|---|---|
+| `ProjectSpecProvider.buildGenericPayloadNodes` — auto-projects any uncovered `ui:treeNode`-bearing payload | `tree_node` | E |
+| `ProjectSpecProvider.buildHlrsNode` / `buildLlrsNode` / `buildTestsNode` / `buildSddNode` — leaf locators read `(tag, idAttr)` from the schema | `tree_node.id_attr`, `element` | H |
+| `CoverageCodeLensProvider.getLensTargets` — inline coverage / tracesCount lenses scan whichever elements declare a supported lens | `lenses[].kind`, `tree_node.id_attr`, `element` | F |
+| `LintDiagnosticsProvider` (via `buildIdScanRegistryFromHints`) — diagnostic ranges resolve any payload's id tokens, not only `HLR-NNN` / `LLR-XXX-NN` | `tree_node.id_attr`, `element` | G |
+
+Adding a new payload with a `<ui:treeNode/>` annotation in
+`tools/project.xsd` therefore surfaces in the tree, lens, and
+diagnostic surfaces with **no TypeScript edits**. Adding a `ui:lens
+kind="coverage"` annotation (and registering the per-element related-
+items handler in `RELATED_DISPATCH`) lights up inline coverage lenses
+on the new payload too.
+
 

--- a/doc/Schema_Reference.md
+++ b/doc/Schema_Reference.md
@@ -41,7 +41,7 @@ generated documents from a single edit point.
 ## 1. Root Element
 
 ```xml
-<project name="Valgrind Parser" short_name="vgp" schema_version="1.2">
+<project name="Valgrind Parser" short_name="vgp" schema_version="1.3">
   <metadata>...</metadata>
   <sdd>...</sdd>
   <stp>...</stp>
@@ -55,14 +55,18 @@ generated documents from a single edit point.
 | --------- | ----------- |
 | `name` | Full project name. |
 | `short_name` | Binary / package name. |
-| `schema_version` | Version of *this* schema. Bump when the structure changes incompatibly. The current schema is `1.2`. |
+| `schema_version` | Version of *this* schema. Bump when the structure changes incompatibly. The current schema is `1.3`. |
 
 The XSD root reserves the namespace prefix `ui` (`urn:tracer:ui:v1`)
 for optional UI-only hints (icon, group, color) that consumers such
 as the VS Code extension may attach to payload elements via
 `ui:*` attributes. The core renderer ignores these attributes; they
 are reserved so that a future hint registry can be added without
-breaking existing files.
+breaking existing files. The `urn:tracer:ui:v1` namespace is also
+used by `<xs:appinfo>` blocks inside
+[tools/project.xsd](../tools/project.xsd) to publish a per-element
+UI hint vocabulary (`ui:treeNode`, `ui:form`, `ui:lens`,
+`ui:document`); see [§16. UI Hint Vocabulary](#16-ui-hint-vocabulary).
 
 Children may appear in any order; the renderer looks them up by tag.
 The XSD declares `<project>`'s children with `xs:all`, so an
@@ -100,7 +104,7 @@ The renderer selects which `<document>` block populates
 (`SDD`, `HLRs`, `LLRs`, `STP`, or `Traceability`). Every generated
 document must have a matching `<document id="...">` entry.
 
-### Optional `template` and `output` attributes (schema_version `1.2`+)
+### Optional `template` and `output` attributes (schema_version `1.3`+)
 
 A `<document>` may carry two optional attributes that decouple the
 document id from its rendering location:
@@ -1083,4 +1087,100 @@ Findings raised before the `code` field was introduced (e.g.
 `<project> is missing required @schema_version`) carry `code: null`.
 New rules added in future phases will document their `code` here;
 existing values are stable and may be relied on by external tooling.
+
+## 16. UI Hint Vocabulary
+
+[tools/project.xsd](../tools/project.xsd) publishes a small UI-hint
+vocabulary in the namespace `urn:tracer:ui:v1` (prefix `ui:`). The
+vocabulary is purely declarative — it is documented inside
+`<xs:annotation><xs:appinfo>` blocks on the renderable complex types
+and is **passed through unchanged by every XSD validator**. Phase
+2.5b consumers (the JSON-RPC sidecar in
+[tools/project_io.py](../tools/project_io.py) and the VS Code
+extension) read these blocks to drive tree nodes, code lenses, and
+form panels with no per-payload code. Adding a new payload to the
+schema therefore requires only an XSD change and a Jinja2 template
+— not a TypeScript edit.
+
+The same namespace is also used by **per-element attributes**
+(`ui:icon`, `ui:color`, `ui:group`) that a project author may attach
+to individual `<hlr>` / `<llr>` / `<test>` / `<module>` elements via
+the `xs:anyAttribute` declarations on those types. Those attributes
+are decoration applied to one specific element; the appinfo
+vocabulary documented below decorates the *complex type* and
+applies uniformly to every instance.
+
+### 16.1 Vocabulary
+
+| Element | Where it appears | Purpose |
+| ------- | ---------------- | ------- |
+| `<ui:treeNode label="..." idAttr="..." group="..."/>` | At most once on a renderable complex type. | Declares that elements of this type appear in the Project Spec tree. `label` is a tiny expression of attribute / child references (`@id` for an attribute value, `@id — @name` for a templated label, a literal string for a fixed label, `name1\|name2` to fall back from one to another). `idAttr` names the attribute used to identify the element for reveal-in-XML. `group` is a slash-separated path under which siblings cluster (e.g. `requirements/hlrs`). |
+| `<ui:form>...</ui:form>` | Up to once per renderable type. Wraps any number of `<ui:field>` children. | Declares the editable surface — what a Phase 3 form panel renders. |
+| `<ui:field attr="..." kind="..." required="..."/>` | One per editable attribute, inside `<ui:form>`. | Describes a single attribute on the parent type. `kind` is one of `text` \| `textarea` \| `enum` \| `ref:HLR` \| `ref:LLR` \| `ref:SDD` \| `cdata`. `required="true"` marks the field as required in the form. |
+| `<ui:field child="..." kind="..." required="..."/>` | One per editable child element, inside `<ui:form>`. | Same as the `attr=` variant but targets a named child element rather than an attribute. `kind="cdata"` is the canonical choice for markdown bodies. |
+| `<ui:lens kind="..."/>` | Zero or more per renderable type. | Attaches a code lens above each instance of this type in `Project.xml`. Built-in `kind` values are `coverage` (HLR/LLR — counts downstream LLRs / tests) and `tracesCount` (HLR / Test — counts incoming `<traces>`). New kinds are added to the lens provider in lockstep with the schema. |
+| `<ui:document/>` | On the `Document` complex type only. | Marks `<metadata><document>` entries as discoverable rendering targets. The `id`, `template`, and `output` attributes documented in [§2 — `<metadata>`](#2-metadata) are the contract; the `<ui:document/>` marker is just the affordance that the discovery surface walks. |
+
+### 16.2 Example
+
+The annotation on the `Hlr` complex type:
+
+```xml
+<xs:complexType name="Hlr">
+  <xs:annotation>
+    <xs:appinfo>
+      <ui:treeNode label="@id — @name" idAttr="id" group="hlrs"/>
+      <ui:form>
+        <ui:field attr="id"      kind="text"    required="true"/>
+        <ui:field attr="name"    kind="text"    required="true"/>
+        <ui:field child="text"   kind="cdata"/>
+        <ui:field child="traces" kind="ref:SDD"/>
+      </ui:form>
+      <ui:lens kind="coverage"/>
+      <ui:lens kind="tracesCount"/>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:sequence>
+    <xs:element name="text"   type="MdText" minOccurs="0"/>
+    <xs:element name="traces" type="Traces" minOccurs="0"/>
+  </xs:sequence>
+  <xs:attribute name="id"   type="HlrId"          use="required"/>
+  <xs:attribute name="name" type="NonEmptyString" use="required"/>
+  <xs:anyAttribute namespace="urn:tracer:ui:v1" processContents="skip"/>
+</xs:complexType>
+```
+
+declares that every `<hlr>`:
+
+* Appears in the Project Spec tree under the `hlrs` group, labelled
+  `HLR-001 — name of the requirement`, identified by its `id`
+  attribute for reveal-in-XML.
+* Edits as a four-field form: text id, text name, CDATA-wrapped
+  markdown body, and a list of `<traces><trace target="SDD" .../>`
+  references.
+* Carries two code lenses — one summarising downstream LLR / test
+  coverage, one counting incoming traces.
+
+### 16.3 Currently annotated types
+
+The vocabulary is published on every renderable type in
+[tools/project.xsd](../tools/project.xsd):
+
+| Type      | `ui:treeNode` group | Lenses                           |
+| --------- | ------------------- | -------------------------------- |
+| `Document` | (no tree node — `ui:document` marker only) | — |
+| `SddModule` | `sdd`              | —                                |
+| `Hlr`     | `hlrs`              | `coverage`, `tracesCount`        |
+| `Llr`     | `llrs`              | `coverage`                       |
+| `Test`    | `tests`             | `tracesCount`                    |
+| `Plan`    | `plan`              | —                                |
+| `Plan/item` | `plan/items`      | —                                |
+
+### 16.4 Stability
+
+The vocabulary's element and attribute names listed in §16.1 are
+**stable** for any consumer reading the XSD. New `ui:lens` kinds and
+new `ui:field` `kind=` values may be added; existing values will not
+change meaning.
+
 

--- a/doc/Schema_Reference.md
+++ b/doc/Schema_Reference.md
@@ -633,9 +633,16 @@ shape:
                  "field":  "text|textarea|enum|ref:HLR|ref:LLR|cdata",
                  "required": true|false}, ...],
   "lenses":    [{"kind": "coverage|tracesCount|..."}, ...],
-  "document":  true|false
+  "document":  true|false,
+  "element":   "hlr" | null
 }
 ```
+
+The `element` field (Slice D) records the lowercase XML element name
+the type is bound to via `<xs:element name="X" type="Y">`. For inline
+nested types like `Plan/item` the field carries the inline element
+name (`"item"`). It lets consumers iterate the parsed tree without
+hard-coding per-payload tag names.
 
 The same index is exposed over the JSON-RPC sidecar:
 
@@ -643,7 +650,14 @@ The same index is exposed over the JSON-RPC sidecar:
 * `parse_to_json({...})` — embeds the same dict under the
   `_ui_hints_index` top-level key alongside the parsed project, so
   the VS Code extension fetches the parsed tree and the hint
-  vocabulary in a single round trip.
+  vocabulary in a single round trip. Slice D additionally embeds a
+  `_nodes` top-level key — a `Record<typeName, ParsedNode[]>` mirror
+  of the index that lists every element in `Project.xml` bound to a
+  type carrying a `ui:treeNode` hint. Each `ParsedNode` is
+  `{tag, attrs, ui, text}` (see [src/sidecar.ts](../tools/vscode-project-xml/src/sidecar.ts)
+  for the TS shape). Inline types are scoped to children of their
+  parent element so unrelated tags with the same local name are not
+  pulled in.
 
 Templates do **not** consume this index — it is dedicated to
 non-Jinja consumers (the VS Code tree provider, lens provider,

--- a/doc/Schema_Reference.md
+++ b/doc/Schema_Reference.md
@@ -41,7 +41,7 @@ generated documents from a single edit point.
 ## 1. Root Element
 
 ```xml
-<project name="Valgrind Parser" short_name="vgp" schema_version="1.3">
+<project name="Valgrind Parser" short_name="vgp" schema_version="1.4">
   <metadata>...</metadata>
   <sdd>...</sdd>
   <stp>...</stp>
@@ -55,7 +55,7 @@ generated documents from a single edit point.
 | --------- | ----------- |
 | `name` | Full project name. |
 | `short_name` | Binary / package name. |
-| `schema_version` | Version of *this* schema. Bump when the structure changes incompatibly. The current schema is `1.3`. |
+| `schema_version` | Version of *this* schema. Bump when the structure changes incompatibly. The current schema is `1.4`. |
 
 The XSD root reserves the namespace prefix `ui` (`urn:tracer:ui:v1`)
 for optional UI-only hints (icon, group, color) that consumers such
@@ -606,6 +606,51 @@ Custom Jinja filters registered by the renderer:
 When extending the schema with a new payload root, add a corresponding
 `build_*` function in `render_doc.py` and expose it on the returned
 `SimpleNamespace` so templates can reach it by attribute access.
+
+### 9.1 UI Hints Index (Phase 2.5b)
+
+Out-of-band of the `project.*` namespace consumed by Jinja templates,
+[tools/render_doc.py](../tools/render_doc.py) also exposes the
+`<xs:appinfo>` UI vocabulary documented in [§16. UI Hint
+Vocabulary](#16-ui-hint-vocabulary) as a JSON-serialisable index:
+
+```python
+from render_doc import parse_ui_hints_index
+index = parse_ui_hints_index()  # reads tools/project.xsd by default
+```
+
+The index is keyed by complex-type name (e.g. `Hlr`, `Llr`, `Test`,
+`SddModule`, `Document`, `Plan`, `Plan/item`). Each entry has the
+shape:
+
+```json
+{
+  "tree_node": {"label": "@id — @name",
+                "id_attr": "id",
+                "group":   "hlrs"} | null,
+  "form":      [{"target": "id",
+                 "kind":   "attr|child",
+                 "field":  "text|textarea|enum|ref:HLR|ref:LLR|cdata",
+                 "required": true|false}, ...],
+  "lenses":    [{"kind": "coverage|tracesCount|..."}, ...],
+  "document":  true|false
+}
+```
+
+The same index is exposed over the JSON-RPC sidecar:
+
+* `ui_hints_index({xsd_path?})` — returns `{"ui_hints_index": {...}}`.
+* `parse_to_json({...})` — embeds the same dict under the
+  `_ui_hints_index` top-level key alongside the parsed project, so
+  the VS Code extension fetches the parsed tree and the hint
+  vocabulary in a single round trip.
+
+Templates do **not** consume this index — it is dedicated to
+non-Jinja consumers (the VS Code tree provider, lens provider,
+locator, and Phase 3 form panels). Adding a new `<ui:lens>` `kind=`
+or a new `<ui:field>` `kind=` requires a matching change in the
+consumer (and a §16 update); the index walker itself accepts any
+attribute set without further code changes.
 
 ## 10. Regeneration
 

--- a/test/doc/Project.xml
+++ b/test/doc/Project.xml
@@ -7,7 +7,7 @@
   payload sections (sdd, stp, hlrs, llrs, tests) as the project takes
   shape, then regenerate the markdown specs with `render_doc.py`.
 -->
-<project name="TraceR Integration Test Fixture" short_name="trft" schema_version="1.3"
+<project name="TraceR Integration Test Fixture" short_name="trft" schema_version="1.4"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="../../tools/project.xsd">
   <metadata>

--- a/test/test_project_io.py
+++ b/test/test_project_io.py
@@ -230,7 +230,7 @@ class MethodsRegistryTests(unittest.TestCase):
         self.assertEqual(
             set(project_io.METHODS.keys()),
             {"lint", "render", "parse_to_json",
-             "list_documents", "init_project"},
+             "list_documents", "ui_hints_index", "init_project"},
         )
         for name, handler in project_io.METHODS.items():
             self.assertTrue(callable(handler), msg=f"{name!r} not callable")
@@ -308,6 +308,58 @@ class SubprocessTests(unittest.TestCase):
         resp = json.loads(proc.stdout.strip())
         self.assertEqual(resp["result"]["errors"], cli_findings.errors)
         self.assertEqual(resp["result"]["warnings"], cli_findings.warnings)
+
+
+class UiHintsIndexTests(unittest.TestCase):
+    """LLR-UHI-01..03 (Phase 2.5b): the `ui_hints_index` JSON-RPC
+    surface distils the `<xs:appinfo>` vocabulary from
+    tools/project.xsd into a JSON-serialisable index keyed by
+    complex-type name; `parse_to_json` embeds the same dict under
+    `_ui_hints_index` so the extension fetches it in one round trip.
+    """
+
+    def test_ui_hints_index_method_returns_index(self) -> None:
+        resp = handle_request({
+            "id": 1, "method": "ui_hints_index",
+            "params": {"xsd_path": str(_paths.PROJECT_XSD)},
+        })
+        self.assertIn("result", resp)
+        index = resp["result"]["ui_hints_index"]
+        # Every renderable complex type with a ui:* annotation must
+        # be present.
+        self.assertEqual(
+            set(index.keys()),
+            {"Document", "SddModule", "Hlr", "Llr", "Test",
+             "Plan", "Plan/item"},
+        )
+        # Hlr carries a tree node, two lenses, and a four-field form.
+        hlr = index["Hlr"]
+        self.assertEqual(hlr["tree_node"]["id_attr"], "id")
+        self.assertEqual(hlr["tree_node"]["group"], "hlrs")
+        self.assertEqual(
+            sorted(l["kind"] for l in hlr["lenses"]),
+            ["coverage", "tracesCount"],
+        )
+        self.assertEqual(len(hlr["form"]), 4)
+        # Document carries the discoverability marker but no tree node.
+        self.assertTrue(index["Document"]["document"])
+        self.assertIsNone(index["Document"]["tree_node"])
+        # The result is JSON-serialisable.
+        json.dumps(resp)
+
+    def test_parse_to_json_embeds_ui_hints_index(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        xml_path = _bootstrap_project(Path(tmp.name))
+        resp = handle_request({
+            "id": 2, "method": "parse_to_json",
+            "params": {"xml_path": str(xml_path)},
+        })
+        self.assertIn("result", resp)
+        self.assertIn("_ui_hints_index", resp["result"])
+        self.assertIn("Hlr", resp["result"]["_ui_hints_index"])
+        # Round-trip through JSON to prove the field is serialisable.
+        json.dumps(resp)
 
 
 if __name__ == "__main__":

--- a/test/test_project_io.py
+++ b/test/test_project_io.py
@@ -361,6 +361,77 @@ class UiHintsIndexTests(unittest.TestCase):
         # Round-trip through JSON to prove the field is serialisable.
         json.dumps(resp)
 
+    def test_ui_hints_index_records_element_binding(self) -> None:
+        """Slice D: each index entry now reports the lowercase XML
+        element bound to its complex type so consumers can iterate
+        the parsed tree without special-casing per tag."""
+        resp = handle_request({
+            "id": 3, "method": "ui_hints_index",
+            "params": {"xsd_path": str(_paths.PROJECT_XSD)},
+        })
+        index = resp["result"]["ui_hints_index"]
+        self.assertEqual(index["Hlr"]["element"], "hlr")
+        self.assertEqual(index["Llr"]["element"], "llr")
+        self.assertEqual(index["Test"]["element"], "test")
+        self.assertEqual(index["SddModule"]["element"], "module")
+        self.assertEqual(index["Plan"]["element"], "plan")
+        self.assertEqual(index["Plan/item"]["element"], "item")
+        self.assertEqual(index["Document"]["element"], "document")
+
+
+class NodesIndexTests(unittest.TestCase):
+    """Slice D (Phase 2.5b): `parse_to_json` embeds a generic
+    `_nodes` map keyed by the same complex-type name as the hints
+    index, listing every element bound to a type that carries a
+    `ui:treeNode` hint. Consumers iterate this map instead of
+    calling per-payload builders.
+    """
+
+    FIXTURE = _paths.REPO_ROOT / "test" / "doc" / "Project.xml"
+
+    def test_parse_to_json_embeds_nodes_index(self) -> None:
+        resp = handle_request({
+            "id": 1, "method": "parse_to_json",
+            "params": {"xml_path": str(self.FIXTURE)},
+        })
+        self.assertIn("result", resp)
+        nodes = resp["result"].get("_nodes")
+        self.assertIsInstance(nodes, dict)
+        # Keys mirror the ui_hints_index entries that have a tree node.
+        # Document is excluded (no tree node); every other annotated
+        # type is present even when the fixture has zero instances.
+        self.assertEqual(
+            set(nodes.keys()),
+            {"Hlr", "Llr", "Test", "SddModule", "Plan", "Plan/item"},
+        )
+        # Round-trip through JSON.
+        json.dumps(resp)
+
+    def test_plan_payload_surfaces_in_nodes_index(self) -> None:
+        """The synthetic `<plan>` payload added in Phase 2.5 Plan-proof
+        must appear in `_nodes` without any TS or Python special-casing
+        — this is the acceptance criterion for the schema-driven
+        projection that Slices E+ will consume."""
+        resp = handle_request({
+            "id": 1, "method": "parse_to_json",
+            "params": {"xml_path": str(self.FIXTURE)},
+        })
+        nodes = resp["result"]["_nodes"]
+        # Exactly one <plan> with a version attribute.
+        self.assertEqual(len(nodes["Plan"]), 1)
+        plan = nodes["Plan"][0]
+        self.assertEqual(plan["tag"], "plan")
+        self.assertIn("version", plan["attrs"])
+        # Inline Plan/item children are scoped under <plan>, not the
+        # whole tree, so unrelated <item> elements would not pollute.
+        items = nodes["Plan/item"]
+        self.assertGreaterEqual(len(items), 1)
+        for item in items:
+            self.assertEqual(item["tag"], "item")
+            self.assertIn("id", item["attrs"])
+        # Each item carries its prose body as `text`.
+        self.assertTrue(any(i.get("text") for i in items))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/project.xsd
+++ b/tools/project.xsd
@@ -23,15 +23,41 @@
   <!-- ============================================================ -->
   <!-- UI hint vocabulary (urn:tracer:ui:v1)                         -->
   <!--                                                               -->
-  <!-- The `ui:` namespace is reserved for `<xs:appinfo>` annotations -->
-  <!-- on payload-bearing elements (e.g. ui:treeNode, ui:form,       -->
-  <!-- ui:lens, ui:document). Phase 2.5 reserves the namespace and   -->
-  <!-- the `<metadata><document>` discovery surface (template/output -->
-  <!-- attributes); Phase 2.5b will define and consume the per-      -->
-  <!-- payload `ui:*` element vocabulary so tree nodes, forms, and   -->
-  <!-- lenses are emitted from the schema with no TypeScript edits.  -->
+  <!-- Each renderable complexType below carries an <xs:annotation>  -->
+  <!-- <xs:appinfo> block describing how the schema element should   -->
+  <!-- be projected to a UI surface:                                 -->
   <!--                                                               -->
-  <!-- See doc/Schema_Reference.md §"UI hints" for the contract.   -->
+  <!--   <ui:treeNode label="..." idAttr="..." group="..."/>          -->
+  <!--     The element appears in the Project Spec tree. `label`      -->
+  <!--     is a small expression of attribute / child references     -->
+  <!--     (e.g. "@id — @name"). `idAttr` names the attribute used    -->
+  <!--     to identify the element (for reveal-in-XML).              -->
+  <!--                                                               -->
+  <!--   <ui:form>                                                   -->
+  <!--     <ui:field attr="id" kind="text" required="true"/>          -->
+  <!--     <ui:field child="text" kind="textarea"/>                  -->
+  <!--     ...                                                       -->
+  <!--   </ui:form>                                                  -->
+  <!--     One <ui:field> per editable attribute or child element.   -->
+  <!--     `kind` is one of text | textarea | enum | ref:HLR |       -->
+  <!--     ref:LLR | cdata.                                          -->
+  <!--                                                               -->
+  <!--   <ui:lens kind="coverage|tracesCount|..."/>                  -->
+  <!--     A code lens to attach inline in Project.xml.              -->
+  <!--                                                               -->
+  <!--   <ui:document/>                                              -->
+  <!--     Marks the element as a discoverable rendering target.     -->
+  <!--     Carried by <metadata><document>.                         -->
+  <!--                                                               -->
+  <!-- The XSD validator passes appinfo through unchanged; consumers -->
+  <!-- (Phase 2.5b's project_io.py and the VS Code extension) read   -->
+  <!-- the blocks to drive tree nodes, lenses, and forms with no     -->
+  <!-- per-payload TypeScript code. The same `urn:tracer:ui:v1`       -->
+  <!-- namespace also accepts per-element `ui:icon` / `ui:color` /   -->
+  <!-- `ui:group` attributes via the existing xs:anyAttribute        -->
+  <!-- declarations on Hlr / Llr / Test / SddModule (Phase 2.5).     -->
+  <!--                                                               -->
+  <!-- See doc/Schema_Reference.md §16 for the full contract.        -->
   <!-- ============================================================ -->
 
   <!-- ============================================================ -->
@@ -80,6 +106,21 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="Document">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:document/>
+        <ui:form>
+          <ui:field attr="id"       kind="text"     required="true"/>
+          <ui:field attr="title"    kind="text"     required="true"/>
+          <ui:field attr="source"   kind="text"     required="true"/>
+          <ui:field attr="version"  kind="text"     required="true"/>
+          <ui:field attr="date"     kind="text"     required="true"/>
+          <ui:field attr="author"   kind="text"     required="true"/>
+          <ui:field attr="template" kind="text"     required="false"/>
+          <ui:field attr="output"   kind="text"     required="false"/>
+        </ui:form>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:attribute name="id"       type="NonEmptyString" use="required"/>
     <xs:attribute name="title"    type="NonEmptyString" use="required"/>
     <xs:attribute name="source"   type="NonEmptyString" use="required"/>
@@ -247,6 +288,19 @@
   </xs:complexType>
 
   <xs:complexType name="SddModule">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:treeNode label="@title|@path" idAttr="path" group="sdd"/>
+        <ui:form>
+          <ui:field attr="path"             kind="text"     required="false"/>
+          <ui:field attr="title"            kind="text"     required="false"/>
+          <ui:field child="purpose"         kind="cdata"/>
+          <ui:field child="responsibility"  kind="cdata"/>
+          <ui:field child="data_structures" kind="cdata"/>
+          <ui:field child="algorithm"       kind="cdata"/>
+        </ui:form>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="purpose"         type="MdText"            minOccurs="0"/>
       <xs:element name="responsibility"  type="MdText"            minOccurs="0" maxOccurs="unbounded"/>
@@ -453,13 +507,26 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="Hlr">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:treeNode label="@id — @name" idAttr="id" group="hlrs"/>
+        <ui:form>
+          <ui:field attr="id"     kind="text"     required="true"/>
+          <ui:field attr="name"   kind="text"     required="true"/>
+          <ui:field child="text"  kind="cdata"/>
+          <ui:field child="traces" kind="ref:SDD"/>
+        </ui:form>
+        <ui:lens kind="coverage"/>
+        <ui:lens kind="tracesCount"/>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="text"   type="MdText" minOccurs="0"/>
       <xs:element name="traces" type="Traces" minOccurs="0"/>
     </xs:sequence>
     <xs:attribute name="id"   type="HlrId"          use="required"/>
     <xs:attribute name="name" type="NonEmptyString" use="required"/>
-    <!-- Phase 2.5b: optional `ui:icon` / `ui:color` / `ui:group` hints   -->
+    <!-- Phase 2.5: optional `ui:icon` / `ui:color` / `ui:group` hints    -->
     <!-- (urn:tracer:ui:v1) consumed by the VS Code tree provider.        -->
     <xs:anyAttribute namespace="urn:tracer:ui:v1" processContents="skip"/>
   </xs:complexType>
@@ -484,6 +551,17 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="Llr">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:treeNode label="@id" idAttr="id" group="llrs"/>
+        <ui:form>
+          <ui:field attr="id"      kind="text"    required="true"/>
+          <ui:field child="text"   kind="cdata"/>
+          <ui:field child="traces" kind="ref:HLR"/>
+        </ui:form>
+        <ui:lens kind="coverage"/>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="text"   type="MdText" minOccurs="0"/>
       <xs:element name="traces" type="Traces" minOccurs="0"/>
@@ -514,6 +592,17 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="Test">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:treeNode label="@name" idAttr="name" group="tests"/>
+        <ui:form>
+          <ui:field attr="name"     kind="text"    required="true"/>
+          <ui:field child="purpose" kind="cdata"/>
+          <ui:field child="traces"  kind="ref:LLR"/>
+        </ui:form>
+        <ui:lens kind="tracesCount"/>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="purpose" type="MdText" minOccurs="0"/>
       <xs:element name="traces"  type="Traces" minOccurs="0"/>
@@ -553,9 +642,26 @@
   <!-- ============================================================ -->
 
   <xs:complexType name="Plan" mixed="true">
+    <xs:annotation>
+      <xs:appinfo>
+        <ui:treeNode label="plan" idAttr="version" group="plan"/>
+        <ui:form>
+          <ui:field attr="version" kind="text" required="false"/>
+        </ui:form>
+      </xs:appinfo>
+    </xs:annotation>
     <xs:sequence>
       <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
         <xs:complexType mixed="true">
+          <xs:annotation>
+            <xs:appinfo>
+              <ui:treeNode label="@id|item" idAttr="id" group="plan/items"/>
+              <ui:form>
+                <ui:field attr="id"     kind="text" required="false"/>
+                <ui:field attr="status" kind="enum" required="false"/>
+              </ui:form>
+            </xs:appinfo>
+          </xs:annotation>
           <xs:attribute name="id"     type="NonEmptyString" use="optional"/>
           <xs:attribute name="status" type="NonEmptyString" use="optional"/>
         </xs:complexType>

--- a/tools/project_io.py
+++ b/tools/project_io.py
@@ -67,6 +67,7 @@ from render_doc import (
     PROJECT_XSD,
     PVD_TEMPLATE,
     ProjectXmlError,
+    collect_nodes_by_type as _collect_nodes_by_type,
     init_project as _init_project,
     list_documents as _list_documents,
     parse_project_to_dict as _parse_project_to_dict,
@@ -137,7 +138,13 @@ def _method_parse_to_json(params: dict[str, Any]) -> dict[str, Any]:
     # alongside the parsed tree so a single round trip gives the
     # extension everything it needs to render schema-driven surfaces.
     # Underscore-prefixed key keeps it out of band of the payload.
-    project["_ui_hints_index"] = _parse_ui_hints_index(PROJECT_XSD)
+    hints_index = _parse_ui_hints_index(PROJECT_XSD)
+    project["_ui_hints_index"] = hints_index
+    # Slice D: also embed a generic node index keyed by the same
+    # complex-type name, so consumers (e.g. the VS Code tree provider)
+    # can iterate every payload that carries a `ui:treeNode` hint
+    # without special-casing per-tag builders.
+    project["_nodes"] = _collect_nodes_by_type(xml_path, hints_index)
     return project
 
 

--- a/tools/project_io.py
+++ b/tools/project_io.py
@@ -17,6 +17,9 @@ lint_project.py as JSON-RPC methods:
         -> {"documents": [{"id", "title", "source", "version",
                            "date", "author", "template", "output"},
                           ...]}
+  * ui_hints_index(xsd_path?)
+        -> {"ui_hints_index": {<ComplexTypeName>: {tree_node, form,
+                               lenses, document}, ...}}
   * init_project(name, short_name, author?, xml_path?, pvd_path?,
                  pvd_template?, force?=False)
         -> {"xml_path": "...", "pvd_path": "...", "existing": [...]}
@@ -61,11 +64,13 @@ from typing import Any, Callable
 # Importable functions from the refactored CLI tools.
 from render_doc import (
     PROJECT_XML,
+    PROJECT_XSD,
     PVD_TEMPLATE,
     ProjectXmlError,
     init_project as _init_project,
     list_documents as _list_documents,
     parse_project_to_dict as _parse_project_to_dict,
+    parse_ui_hints_index as _parse_ui_hints_index,
     render_document as _render_document,
 )
 from lint_project import (
@@ -127,12 +132,32 @@ def _method_parse_to_json(params: dict[str, Any]) -> dict[str, Any]:
     metadata_for = params.get("metadata_for")
     if metadata_for is not None and not isinstance(metadata_for, str):
         raise ValueError("metadata_for must be a string or null")
-    return _parse_project_to_dict(xml_path, metadata_for)
+    project = _parse_project_to_dict(xml_path, metadata_for)
+    # Phase 2.5b: embed the UI hint index distilled from the XSD
+    # alongside the parsed tree so a single round trip gives the
+    # extension everything it needs to render schema-driven surfaces.
+    # Underscore-prefixed key keeps it out of band of the payload.
+    project["_ui_hints_index"] = _parse_ui_hints_index(PROJECT_XSD)
+    return project
 
 
 def _method_list_documents(params: dict[str, Any]) -> dict[str, Any]:
     xml_path = _as_path(params.get("xml_path"), PROJECT_XML)
     return {"documents": _list_documents(xml_path)}
+
+
+def _method_ui_hints_index(params: dict[str, Any]) -> dict[str, Any]:
+    """Phase 2.5b JSON-RPC surface: distil the per-complex-type UI
+    hint vocabulary from ``tools/project.xsd`` (`<xs:appinfo>` blocks)
+    and return a JSON-serialisable index keyed by complex-type name.
+    Used by the VS Code extension's tree provider, lens provider,
+    locator, and Phase 3 form panels.
+
+    See doc/Schema_Reference.md §16 for the vocabulary contract and
+    §9 for the Renderer Data Surface field.
+    """
+    xsd_path = _as_path(params.get("xsd_path"), PROJECT_XSD)
+    return {"ui_hints_index": _parse_ui_hints_index(xsd_path)}
 
 
 def _method_init_project(params: dict[str, Any]) -> dict[str, Any]:
@@ -167,6 +192,7 @@ METHODS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "render": _method_render,
     "parse_to_json": _method_parse_to_json,
     "list_documents": _method_list_documents,
+    "ui_hints_index": _method_ui_hints_index,
     "init_project": _method_init_project,
 }
 

--- a/tools/render_doc.py
+++ b/tools/render_doc.py
@@ -161,6 +161,10 @@ def _parse_appinfo(appinfo: ET.Element) -> dict[str, Any]:
         "form":      form,
         "lenses":    lenses,
         "document":  document,
+        # `element` (the lowercase XML tag bound to this complex type)
+        # is filled in by parse_ui_hints_index after a second pass
+        # over the XSD's <xs:element type="..."> declarations.
+        "element":   None,
     }
 
 
@@ -223,8 +227,106 @@ def parse_ui_hints_index(
             if not local:
                 continue
             _walk_complextype(inline, f"{name}/{local}")
+            # Inline complex types are bound to their own element name.
+            if f"{name}/{local}" in index:
+                index[f"{name}/{local}"]["element"] = local
+
+    # Second pass: bind top-level named types to the lowercase XML
+    # element name(s) they appear under (xs:element name="X" type="Y").
+    # If a type is bound to multiple element names we keep the first;
+    # all currently-annotated types are 1:1.
+    for elem in root.iter(element_tag):
+        type_attr = elem.get("type")
+        local = elem.get("name")
+        if not type_attr or not local:
+            continue
+        if type_attr in index and index[type_attr]["element"] is None:
+            index[type_attr]["element"] = local
 
     return index
+
+
+def collect_nodes_by_type(
+    xml_path: Path | str = PROJECT_XML,
+    hints_index: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Walk Project.xml and collect every element bound to a complex
+    type that carries a ``ui:treeNode`` hint, keyed by the same
+    complex-type name used by :func:`parse_ui_hints_index`.
+
+    Each emitted node is a JSON-serialisable dict::
+
+        {
+            "tag":   "hlr",                     # actual XML local name
+            "attrs": {"id": "HLR-001", ...},     # non-namespaced attrs
+            "ui":    {"icon": "star", ...} | None,  # urn:tracer:ui:v1 attrs
+            "text":  "..." | None,                # stripped element.text
+        }
+
+    Inline nested types (e.g. ``Plan/item``) are scoped to children of
+    their parent element so unrelated ``<item>`` elements elsewhere in
+    the tree are not pulled in.
+
+    Types whose ``tree_node`` hint is None are skipped; the index is
+    only useful to consumers that want to render those nodes (the
+    VS Code Project Spec tree provider, Phase 2.5b Slice E+).
+    """
+    xml_path = Path(xml_path)
+    if hints_index is None:
+        hints_index = parse_ui_hints_index()
+    try:
+        root = ET.parse(xml_path).getroot()
+    except ET.ParseError as exc:
+        raise ProjectXmlError(
+            f"{xml_path}: malformed XML: {exc}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise ProjectXmlError(f"{xml_path}: file not found") from exc
+
+    def _node_payload(elem: ET.Element) -> dict[str, Any]:
+        attrs: dict[str, str] = {}
+        ui: dict[str, str] = {}
+        for k, v in elem.attrib.items():
+            if k.startswith("{"):
+                ns, local = k[1:].split("}", 1)
+                if ns == UI_NAMESPACE:
+                    ui[local] = v
+                # Other foreign-namespace attrs are dropped.
+            else:
+                attrs[k] = v
+        text = (elem.text or "").strip() or None
+        return {
+            "tag":   elem.tag,
+            "attrs": attrs,
+            "ui":    ui or None,
+            "text":  text,
+        }
+
+    nodes: dict[str, list[dict[str, Any]]] = {}
+
+    for key, entry in hints_index.items():
+        if entry.get("tree_node") is None:
+            continue
+        element = entry.get("element")
+        if not element:
+            continue
+        if "/" in key:
+            # Inline type: scope to the parent type's element.
+            parent_key = key.split("/", 1)[0]
+            parent_element = (hints_index.get(parent_key) or {}).get("element")
+            if not parent_element:
+                continue
+            collected: list[dict[str, Any]] = []
+            for parent in root.iter(parent_element):
+                for child in parent.iter(element):
+                    if child is parent:
+                        continue
+                    collected.append(_node_payload(child))
+            nodes[key] = collected
+        else:
+            nodes[key] = [_node_payload(e) for e in root.iter(element)]
+
+    return nodes
 
 
 

--- a/tools/render_doc.py
+++ b/tools/render_doc.py
@@ -68,6 +68,166 @@ def _ui_hints(elem: ET.Element) -> dict[str, str] | None:
     return hints or None
 
 
+# ---------------------------------------------------------------------------
+# UI hint vocabulary distilled from <xs:appinfo> in tools/project.xsd
+# (Phase 2.5b).
+#
+# Every renderable complex type in the XSD carries an
+# <xs:annotation><xs:appinfo> block declaring how the schema element
+# should be projected to a UI surface — `ui:treeNode`, `ui:form`,
+# `ui:lens`, `ui:document`. parse_ui_hints_index walks the XSD once
+# and returns a single dict keyed by complex-type name. Consumers
+# (the VS Code tree provider, lens provider, locator, and Phase 3
+# form panels) read this index instead of re-parsing the XSD or
+# special-casing per-payload element names.
+#
+# Shape:
+#
+#   {
+#     "Hlr": {
+#       "tree_node": {"label": "@id — @name",
+#                     "id_attr": "id",
+#                     "group":   "hlrs"},
+#       "form":      [{"target": "id",
+#                      "kind":   "attr",
+#                      "field":  "text",
+#                      "required": True}, ...],
+#       "lenses":    [{"kind": "coverage"}, {"kind": "tracesCount"}],
+#       "document":  False,
+#     },
+#     ...
+#   }
+#
+# Types without an <xs:appinfo> block are absent from the index;
+# missing sub-fields default to None (tree_node) or [] (form, lenses).
+# The index is JSON-serialisable.
+# ---------------------------------------------------------------------------
+
+_XS_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+
+
+def _local(tag: str) -> str:
+    return tag.split("}", 1)[1] if tag.startswith("{") else tag
+
+
+def _ui_local(tag: str) -> str | None:
+    if not tag.startswith("{"):
+        return None
+    ns, local = tag[1:].split("}", 1)
+    return local if ns == UI_NAMESPACE else None
+
+
+def _parse_ui_field(elem: ET.Element) -> dict[str, Any]:
+    attrs = elem.attrib
+    if "attr" in attrs:
+        target, kind = attrs["attr"], "attr"
+    elif "child" in attrs:
+        target, kind = attrs["child"], "child"
+    else:
+        target, kind = "", "attr"
+    return {
+        "target":   target,
+        "kind":     kind,
+        "field":    attrs.get("kind", "text"),
+        "required": attrs.get("required", "").lower() == "true",
+    }
+
+
+def _parse_appinfo(appinfo: ET.Element) -> dict[str, Any]:
+    tree_node: dict[str, str] | None = None
+    form: list[dict[str, Any]] = []
+    lenses: list[dict[str, str]] = []
+    document = False
+    for child in appinfo:
+        local = _ui_local(child.tag)
+        if local is None:
+            continue
+        if local == "treeNode":
+            tree_node = {
+                "label":   child.get("label", ""),
+                "id_attr": child.get("idAttr", ""),
+                "group":   child.get("group", ""),
+            }
+        elif local == "form":
+            for field_elem in child:
+                if _ui_local(field_elem.tag) == "field":
+                    form.append(_parse_ui_field(field_elem))
+        elif local == "lens":
+            lenses.append({"kind": child.get("kind", "")})
+        elif local == "document":
+            document = True
+    return {
+        "tree_node": tree_node,
+        "form":      form,
+        "lenses":    lenses,
+        "document":  document,
+    }
+
+
+def parse_ui_hints_index(
+    xsd_path: Path | str = PROJECT_XSD,
+) -> dict[str, dict[str, Any]]:
+    """Distil the per-complex-type UI hint vocabulary from
+    ``tools/project.xsd``.
+
+    Walks every ``xs:complexType`` in the schema, reads any
+    ``xs:annotation/xs:appinfo`` block under it, and projects the
+    ``ui:treeNode`` / ``ui:form`` / ``ui:lens`` / ``ui:document``
+    children into a JSON-serialisable index keyed by the type's
+    ``@name``. Anonymous inline complex types (those declared inside
+    an ``xs:element``) are walked too and keyed under the parent
+    element's local name (e.g. ``Plan/item``).
+
+    Pinned by Schema_Reference.md §16 and consumed by
+    [tools/project_io.py](project_io.py)'s ``ui_hints_index`` and
+    ``parse_to_json`` JSON-RPC methods (Phase 2.5b).
+    """
+    xsd_path = Path(xsd_path)
+    try:
+        root = ET.parse(xsd_path).getroot()
+    except ET.ParseError as exc:
+        raise ProjectXmlError(
+            f"{xsd_path}: malformed XSD: {exc}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise ProjectXmlError(f"{xsd_path}: file not found") from exc
+
+    appinfo_tag    = f"{{{_XS_NAMESPACE}}}appinfo"
+    annotation_tag = f"{{{_XS_NAMESPACE}}}annotation"
+    complextype_tag = f"{{{_XS_NAMESPACE}}}complexType"
+    element_tag    = f"{{{_XS_NAMESPACE}}}element"
+
+    index: dict[str, dict[str, Any]] = {}
+
+    def _walk_complextype(node: ET.Element, key: str) -> None:
+        annotation = node.find(annotation_tag)
+        if annotation is None:
+            return
+        appinfo = annotation.find(appinfo_tag)
+        if appinfo is None:
+            return
+        index[key] = _parse_appinfo(appinfo)
+
+    # Top-level named complex types.
+    for ct in root.findall(complextype_tag):
+        name = ct.get("name")
+        if not name:
+            continue
+        _walk_complextype(ct, name)
+        # Inline nested complex types under named elements (e.g. Plan/item).
+        for elem in ct.iter(element_tag):
+            inline = elem.find(complextype_tag)
+            if inline is None:
+                continue
+            local = elem.get("name")
+            if not local:
+                continue
+            _walk_complextype(inline, f"{name}/{local}")
+
+    return index
+
+
+
 def _text(elem: ET.Element | None) -> str:
     if elem is None or elem.text is None:
         return ""

--- a/tools/vscode-project-xml/src/codeLens/CoverageCodeLensProvider.ts
+++ b/tools/vscode-project-xml/src/codeLens/CoverageCodeLensProvider.ts
@@ -17,11 +17,12 @@
 //     <traces> reference it.
 //   * For a test: count the LLR and HLR traces it carries.
 //
-// The provider hard-codes the three element selectors per the Phase
-// 2 prompt; the Phase 2.5 retrofit replaces the selectors with a
-// walk over `ui_hints_index.lenses`. The coverage / per-related-id
-// computations move into named lens kinds at that point and the
-// provider becomes payload-agnostic.
+// Phase 2.5b Slice F: the (element, id_attr) pairs scanned for lenses
+// are no longer hard-coded -- they come from `_ui_hints_index` filtered
+// to entries whose `lenses` contains a `coverage` or `tracesCount`
+// kind. Adding a new payload with one of those lens kinds wires the
+// regex/range pass automatically; the `RELATED_DISPATCH` registry
+// below is the only place that still encodes per-payload semantics.
 
 import * as vscode from 'vscode';
 import {
@@ -30,6 +31,7 @@ import {
     ParsedProject,
     ParsedTest,
     ProjectIoClient,
+    UiHintsIndex,
 } from '../sidecar';
 import { getProjectXmlPath } from '../util/paths';
 import { RevealLocator } from '../treeView/ProjectSpecProvider';
@@ -112,29 +114,24 @@ export class CoverageCodeLensProvider
         const lenses: vscode.CodeLens[] = [];
         const text = document.getText();
 
-        for (const match of matchAll(text, /<hlr\b[^>]*?\bid="([^"]+)"/g)) {
-            const range = rangeAt(document, match.index);
-            const id = match[1];
-            const related = relatedForHlr(id, index);
-            pushLenses(lenses, range, summaryForHlr(related), `HLR ${id}`, related);
-        }
-        for (const match of matchAll(text, /<llr\b[^>]*?\bid="([^"]+)"/g)) {
-            const range = rangeAt(document, match.index);
-            const id = match[1];
-            const related = relatedForLlr(id, index);
-            pushLenses(lenses, range, summaryForLlr(related), `LLR ${id}`, related);
-        }
-        for (const match of matchAll(text, /<test\b[^>]*?\bname="([^"]+)"/g)) {
-            const range = rangeAt(document, match.index);
-            const name = match[1];
-            const related = relatedForTest(name, index);
-            pushLenses(
-                lenses,
-                range,
-                summaryForTest(related),
-                `test ${name}`,
-                related,
-            );
+        for (const target of getLensTargets(project._ui_hints_index)) {
+            const handler = RELATED_DISPATCH[target.element];
+            if (!handler) {
+                continue;
+            }
+            const regex = buildElementIdRegex(target.element, target.idAttr);
+            for (const match of matchAll(text, regex)) {
+                const range = rangeAt(document, match.index);
+                const value = match[1];
+                const related = handler(value, index);
+                pushLenses(
+                    lenses,
+                    range,
+                    target.summary(related),
+                    `${target.label} ${value}`,
+                    related,
+                );
+            }
         }
         return lenses;
     }
@@ -475,4 +472,116 @@ function* matchAll(text: string, re: RegExp): Generator<RegExpExecArray> {
             re.lastIndex++;
         }
     }
+}
+
+// ---------------------------------------------------------------------
+// Phase 2.5b Slice F: schema-driven lens targets
+// ---------------------------------------------------------------------
+
+/**
+ * Per-element coverage handler. Each entry knows how to enumerate
+ * "related" items (LLRs, HLRs, tests) for one parsed element value
+ * and how to summarise the result for the summary lens. The dispatch
+ * table is the only payload-aware code path left in this provider --
+ * the (element, id_attr) pairs scanned for lenses are derived from
+ * `_ui_hints_index` at call time.
+ */
+type RelatedHandler = (value: string, index: CoverageIndex) => RelatedItem[];
+type SummaryFn = (related: RelatedItem[]) => string;
+
+interface LensTarget {
+    readonly element: string;
+    readonly idAttr: string;
+    readonly label: string;
+    readonly summary: SummaryFn;
+}
+
+/** Lens kinds that this provider knows how to render. */
+const SUPPORTED_LENS_KINDS = new Set(['coverage', 'tracesCount']);
+
+/** Maps the lowercase XML tag (UiHintEntry.element) to the per-element
+ *  related-item lookup. Adding a fourth payload with a coverage lens
+ *  in the schema is then a one-line registration here. */
+const RELATED_DISPATCH: Record<string, RelatedHandler> = {
+    hlr:  relatedForHlr,
+    llr:  relatedForLlr,
+    test: relatedForTest,
+};
+
+/** User-visible labels for each known element. */
+const ELEMENT_LABELS: Record<string, string> = {
+    hlr:  'HLR',
+    llr:  'LLR',
+    test: 'test',
+};
+
+/** Per-element summary text strategy. */
+const SUMMARY_DISPATCH: Record<string, SummaryFn> = {
+    hlr:  summaryForHlr,
+    llr:  summaryForLlr,
+    test: summaryForTest,
+};
+
+/**
+ * Walk `_ui_hints_index` and return the ordered list of elements
+ * whose schema annotations declare a supported lens kind. Falls back
+ * to the legacy hard-coded HLR/LLR/Test triple when the sidecar did
+ * not provide an index (older Python builds, or `parse_to_json`
+ * failure paths that still return a partial result).
+ *
+ * Exported for tier-1 tests.
+ */
+export function getLensTargets(
+    hints: UiHintsIndex | undefined,
+): LensTarget[] {
+    if (!hints) {
+        return LEGACY_LENS_TARGETS;
+    }
+    const out: LensTarget[] = [];
+    const seen = new Set<string>();
+    for (const key of Object.keys(hints)) {
+        const entry = hints[key];
+        if (!entry?.element || !entry.tree_node) {
+            continue;
+        }
+        const wanted = entry.lenses.some((l) => SUPPORTED_LENS_KINDS.has(l.kind));
+        if (!wanted) {
+            continue;
+        }
+        if (seen.has(entry.element)) {
+            continue;
+        }
+        seen.add(entry.element);
+        out.push({
+            element: entry.element,
+            idAttr:  entry.tree_node.id_attr || 'id',
+            label:   ELEMENT_LABELS[entry.element]
+                  ?? entry.element.toUpperCase(),
+            summary: SUMMARY_DISPATCH[entry.element] ?? defaultSummary,
+        });
+    }
+    return out.length > 0 ? out : LEGACY_LENS_TARGETS;
+}
+
+const LEGACY_LENS_TARGETS: LensTarget[] = [
+    { element: 'hlr',  idAttr: 'id',   label: 'HLR',  summary: summaryForHlr  },
+    { element: 'llr',  idAttr: 'id',   label: 'LLR',  summary: summaryForLlr  },
+    { element: 'test', idAttr: 'name', label: 'test', summary: summaryForTest },
+];
+
+function defaultSummary(related: RelatedItem[]): string {
+    return pluralize(related.length, 'related');
+}
+
+/** Exported for tier-1 tests. */
+export const _RELATED_DISPATCH = RELATED_DISPATCH;
+/** Exported for tier-1 tests. */
+export const _SUPPORTED_LENS_KINDS = SUPPORTED_LENS_KINDS;
+
+const ATTR_ESCAPE = /[.*+?^${}()|[\]\\]/g;
+
+function buildElementIdRegex(element: string, idAttr: string): RegExp {
+    const tag  = element.replace(ATTR_ESCAPE, '\\$&');
+    const attr = idAttr.replace(ATTR_ESCAPE, '\\$&');
+    return new RegExp(`<${tag}\\b[^>]*?\\b${attr}="([^"]+)"`, 'g');
 }

--- a/tools/vscode-project-xml/src/diagnostics/LintDiagnosticsProvider.ts
+++ b/tools/vscode-project-xml/src/diagnostics/LintDiagnosticsProvider.ts
@@ -6,14 +6,24 @@
 // it in the Problems panel.
 
 import * as vscode from 'vscode';
-import { ProjectIoClient, LintResult } from '../sidecar';
+import { ProjectIoClient, LintResult, UiHintsIndex } from '../sidecar';
 import { getProjectXmlPath, getProjectXmlUri, getXsdPath } from '../util/paths';
-import { rangeForFinding } from '../util/locator';
+import {
+    DEFAULT_ID_SCAN_REGISTRY,
+    IdScanEntry,
+    buildIdScanRegistryFromHints,
+    rangeForFinding,
+} from '../util/locator';
 
 const SOURCE = 'projectXml';
 
 export class LintDiagnosticsProvider implements vscode.Disposable {
     private readonly collection: vscode.DiagnosticCollection;
+    /** Cached schema-derived id-scan registry. Populated on first
+     *  successful `ui_hints_index` call; falls back to the legacy
+     *  HLR/LLR pair when the sidecar can't supply hints. */
+    private idScanRegistry: IdScanEntry[] = DEFAULT_ID_SCAN_REGISTRY;
+    private hintsLoaded = false;
 
     constructor(
         private readonly client: ProjectIoClient,
@@ -28,6 +38,7 @@ export class LintDiagnosticsProvider implements vscode.Disposable {
         if (!xmlPath || !xmlUri) {
             return undefined;
         }
+        await this.ensureHints();
         const xsdPath = getXsdPath();
         const params: Record<string, unknown> = { xml_path: xmlPath };
         if (xsdPath) {
@@ -64,17 +75,39 @@ export class LintDiagnosticsProvider implements vscode.Disposable {
 
         const diagnostics: vscode.Diagnostic[] = [];
         for (const msg of result.errors) {
-            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Error));
+            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Error, this.idScanRegistry));
         }
         for (const msg of result.warnings) {
-            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Warning));
+            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Warning, this.idScanRegistry));
         }
         for (const msg of result.notes) {
-            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Information));
+            diagnostics.push(makeDiagnostic(doc, msg, vscode.DiagnosticSeverity.Information, this.idScanRegistry));
         }
         this.collection.set(uri, diagnostics);
     }
-
+    /**
+     * Phase 2.5b Slice G: pull `_ui_hints_index` from the sidecar on
+     * first use and derive a payload-aware id-scan registry from it.
+     * Falls back silently to the legacy HLR/LLR pair when the call
+     * fails (older sidecar, transient error). Re-fetched once per
+     * provider lifetime; refresh on workspace reload.
+     */
+    private async ensureHints(): Promise<void> {
+        if (this.hintsLoaded) {
+            return;
+        }
+        this.hintsLoaded = true;
+        try {
+            const resp = await this.client.uiHintsIndex();
+            const hints = resp.ui_hints_index as unknown as UiHintsIndex;
+            this.idScanRegistry = buildIdScanRegistryFromHints(hints);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            this.outputChannel.appendLine(
+                `[lint] ui_hints_index unavailable, using legacy id scan: ${message}`,
+            );
+        }
+    }
     clear(): void {
         this.collection.clear();
     }
@@ -88,8 +121,9 @@ function makeDiagnostic(
     doc: vscode.TextDocument,
     message: string,
     severity: vscode.DiagnosticSeverity,
+    registry: IdScanEntry[],
 ): vscode.Diagnostic {
-    const diag = new vscode.Diagnostic(rangeForFinding(doc, message), message, severity);
+    const diag = new vscode.Diagnostic(rangeForFinding(doc, message, registry), message, severity);
     diag.source = SOURCE;
     return diag;
 }

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -49,6 +49,12 @@ export class ProjectIoClient implements vscode.Disposable {
         return this.request<ListDocumentsResult>('list_documents', params);
     }
 
+    async uiHintsIndex(
+        params: Record<string, unknown> = {},
+    ): Promise<UiHintsIndexResult> {
+        return this.request<UiHintsIndexResult>('ui_hints_index', params);
+    }
+
     async render(params: RenderParams): Promise<RenderResult> {
         return this.request<RenderResult>('render', params as unknown as Record<string, unknown>);
     }
@@ -241,6 +247,60 @@ export interface RenderResult {
     out_path: string | null;
 }
 
+/**
+ * Phase 2.5b UI hint vocabulary distilled from `<xs:appinfo>` blocks
+ * in `tools/project.xsd` (urn:tracer:ui:v1).
+ *
+ * The Python sidecar's `ui_hints_index` method walks every renderable
+ * complex type in the schema and returns one entry per type, keyed by
+ * the type's `@name`. Inline complex types under named elements are
+ * keyed under the parent (e.g. `Plan/item`). Types without a
+ * `<xs:appinfo>` block are absent from the index.
+ *
+ * Phase 2.5b consumers (the generic tree provider, lens provider,
+ * locator, and Phase 3 form panels) read this index instead of
+ * special-casing per-payload element names.
+ *
+ * See doc/Schema_Reference.md §16 for the contract.
+ */
+export interface UiTreeNode {
+    label: string;
+    /** Attribute used to identify the element for reveal-in-XML. */
+    id_attr: string;
+    /** Slash-separated path under which siblings cluster (e.g. `hlrs`). */
+    group: string;
+}
+
+export interface UiFormField {
+    /** Name of the attribute or child element this field edits. */
+    target: string;
+    /** Whether the field targets an attribute (`attr`) or child (`child`). */
+    kind: 'attr' | 'child';
+    /** Editor type: `text` | `textarea` | `enum` | `ref:HLR` | `ref:LLR` | `ref:SDD` | `cdata`. */
+    field: string;
+    required: boolean;
+}
+
+export interface UiLens {
+    /** `coverage`, `tracesCount`, or a custom kind handled by the lens provider. */
+    kind: string;
+}
+
+export interface UiHintEntry {
+    tree_node: UiTreeNode | null;
+    form: UiFormField[];
+    lenses: UiLens[];
+    /** True for `Document` (the discoverability marker) and any other
+     *  type that carries `<ui:document/>`. */
+    document: boolean;
+}
+
+export type UiHintsIndex = Record<string, UiHintEntry>;
+
+export interface UiHintsIndexResult {
+    ui_hints_index: UiHintsIndex;
+}
+
 export interface ParsedSection {
     number?: string;
     title?: string;
@@ -338,4 +398,9 @@ export interface ParsedProject {
     flat_hlrs?: ParsedHlr[];
     flat_llrs?: ParsedLlr[];
     flat_tests?: ParsedTest[];
+    /** Phase 2.5b: the same UI hint vocabulary returned by
+     *  `ui_hints_index`, embedded under an underscore-prefixed key so
+     *  callers fetch parse + hints in one round trip. Absent on older
+     *  sidecars. */
+    _ui_hints_index?: UiHintsIndex;
 }

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -293,6 +293,12 @@ export interface UiHintEntry {
     /** True for `Document` (the discoverability marker) and any other
      *  type that carries `<ui:document/>`. */
     document: boolean;
+    /** Slice D: the lowercase XML element bound to this complex type
+     *  (e.g. `"hlr"` for `Hlr`, `"item"` for `Plan/item`). Lets
+     *  consumers iterate the parsed tree without hard-coding tag
+     *  names. Null when no `<xs:element type="...">` declaration
+     *  binds the type. */
+    element: string | null;
 }
 
 export type UiHintsIndex = Record<string, UiHintEntry>;
@@ -300,6 +306,28 @@ export type UiHintsIndex = Record<string, UiHintEntry>;
 export interface UiHintsIndexResult {
     ui_hints_index: UiHintsIndex;
 }
+
+/**
+ * Phase 2.5b Slice D: a generic parsed node, surfaced under
+ * `ParsedProject._nodes` and keyed by complex-type name (matching
+ * `UiHintsIndex`). Lets the tree provider, lens provider, and Phase
+ * 3 form panels iterate every payload that carries a `ui:treeNode`
+ * hint without referencing per-payload tag names.
+ */
+export interface ParsedNode {
+    /** Actual lowercase XML element name (matches `UiHintEntry.element`). */
+    tag: string;
+    /** Non-namespaced XML attributes verbatim from the source. */
+    attrs: Record<string, string>;
+    /** Attributes from the `urn:tracer:ui:v1` namespace (icon, color,
+     *  group, ...) collected separately so the tree provider can
+     *  apply them via `applyHintsToNode()`. Null when no UI attrs. */
+    ui: Record<string, string> | null;
+    /** Stripped element text content; null when empty. */
+    text: string | null;
+}
+
+export type ParsedNodesIndex = Record<string, ParsedNode[]>;
 
 export interface ParsedSection {
     number?: string;
@@ -403,4 +431,9 @@ export interface ParsedProject {
      *  callers fetch parse + hints in one round trip. Absent on older
      *  sidecars. */
     _ui_hints_index?: UiHintsIndex;
+    /** Slice D: generic parsed-node index keyed by complex-type name.
+     *  Mirrors `_ui_hints_index` so a single round trip surfaces every
+     *  payload that carries a `ui:treeNode` hint without per-tag
+     *  builders. Absent on older sidecars. */
+    _nodes?: ParsedNodesIndex;
 }

--- a/tools/vscode-project-xml/src/treeView/ProjectSpecProvider.ts
+++ b/tools/vscode-project-xml/src/treeView/ProjectSpecProvider.ts
@@ -8,7 +8,12 @@
 // but cannot be revealed.
 
 import * as vscode from 'vscode';
-import { ProjectIoClient, ParsedProject } from '../sidecar';
+import {
+    ParsedNode,
+    ParsedProject,
+    ProjectIoClient,
+    UiHintEntry,
+} from '../sidecar';
 import { BadgeIndex } from '../util/badges';
 import { applyHintsToNode } from '../util/hints';
 import { getConfig, getProjectXmlPath } from '../util/paths';
@@ -110,7 +115,90 @@ function buildTopLevel(
         buildTestsNode(project),
         buildSddNode(project),
         buildStpNode(project),
+        ...buildGenericPayloadNodes(project),
     ];
+}
+
+/**
+ * Phase 2.5b Slice E: schema-driven extension point.
+ *
+ * Walks `project._nodes` (the `Record<typeName, ParsedNode[]>` index
+ * embedded by `parse_to_json` since Slice D) and emits one top-level
+ * tree group for every type-key NOT already covered by the typed
+ * builders above. This is the seam that makes adding a new payload
+ * a zero-TS-edit operation: declare a `<xs:appinfo><ui:treeNode/>`
+ * block on a new complex type in `tools/project.xsd`, render the
+ * node's body in your Jinja template, and the Project Spec view
+ * picks it up automatically.
+ *
+ * The legacy buildHlrsNode / buildLlrsNode / buildTestsNode /
+ * buildSddNode / buildStpNode functions stay in place because they
+ * preserve UX nesting (HLR sections, LLR function groups, test
+ * files) that the generic walker can't recover from a flat node
+ * list. Migrating those onto this seam is a follow-up slice.
+ */
+function buildGenericPayloadNodes(project: ParsedProject): ProjectSpecNode[] {
+    const nodes = project._nodes ?? {};
+    const hints = project._ui_hints_index ?? {};
+    const out: ProjectSpecNode[] = [];
+    // Stable order: type-keys sorted alphabetically.
+    for (const key of Object.keys(nodes).sort()) {
+        if (COVERED_TYPE_KEYS.has(key)) {
+            continue;
+        }
+        const entry = hints[key];
+        if (!entry || !entry.tree_node || !entry.element) {
+            continue;
+        }
+        out.push(buildGenericGroup(key, entry, nodes[key] ?? []));
+    }
+    return out;
+}
+
+function buildGenericGroup(
+    key: string,
+    entry: UiHintEntry,
+    parsedNodes: ParsedNode[],
+): ProjectSpecNode {
+    const tag = entry.element ?? key.toLowerCase();
+    const idAttr = entry.tree_node?.id_attr ?? 'id';
+    const labelTemplate = entry.tree_node?.label || `@${idAttr}`;
+    const children = parsedNodes.map((n) => {
+        const value = n.attrs[idAttr] ?? '';
+        const leaf = new ProjectSpecNode(
+            renderLabel(labelTemplate, n) || `(${tag})`,
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            value
+                ? { tag, attr: idAttr, value }
+                : undefined,
+        );
+        applyHintsToNode(leaf, n.ui ?? undefined);
+        return leaf;
+    });
+    const node = new ProjectSpecNode(
+        `${key} (${parsedNodes.length})`,
+        children.length > 0
+            ? vscode.TreeItemCollapsibleState.Collapsed
+            : vscode.TreeItemCollapsibleState.None,
+        children,
+    );
+    node.iconPath = new vscode.ThemeIcon('symbol-misc');
+    return node;
+}
+
+/**
+ * Substitute `@<attr>` tokens in a `ui:treeNode/@label` template with
+ * values from `node.attrs`. Unknown tokens collapse to empty string.
+ * Trims redundant whitespace so a template like `"@id — @name"` with
+ * no `name` attribute renders as just `"HLR-001"`, not `"HLR-001 — "`.
+ */
+function renderLabel(template: string, node: ParsedNode): string {
+    const raw = template.replace(
+        /@([A-Za-z_][\w-]*)/g,
+        (_m, name: string) => node.attrs[name] ?? '',
+    );
+    return raw.replace(/\s+[—-]\s+(?=$|\s)/g, '').replace(/\s+/g, ' ').trim();
 }
 
 function badgesEnabled(): boolean {
@@ -122,6 +210,26 @@ function decorate(
     badge: string | undefined,
 ): string {
     return badge ? `${badge} ${label}` : label;
+}
+
+/** Exported for tier-1 tests. */
+export const COVERED_TYPE_KEYS = new Set([
+    'Hlr',
+    'Llr',
+    'Test',
+    'SddModule',
+]);
+
+/** Exported for tier-1 tests. */
+export function _buildGenericPayloadNodes(
+    project: ParsedProject,
+): ProjectSpecNode[] {
+    return buildGenericPayloadNodes(project);
+}
+
+/** Exported for tier-1 tests. */
+export function _renderLabel(template: string, node: ParsedNode): string {
+    return renderLabel(template, node);
 }
 
 function buildHlrsNode(

--- a/tools/vscode-project-xml/src/treeView/ProjectSpecProvider.ts
+++ b/tools/vscode-project-xml/src/treeView/ProjectSpecProvider.ts
@@ -109,14 +109,52 @@ function buildTopLevel(
     project: ParsedProject,
     badges: BadgeIndex | undefined,
 ): ProjectSpecNode[] {
+    const hints = project._ui_hints_index;
     return [
-        buildHlrsNode(project, badges),
-        buildLlrsNode(project, badges),
-        buildTestsNode(project),
-        buildSddNode(project),
+        buildHlrsNode(project, badges, locatorMeta(hints, 'Hlr', 'hlr', 'id')),
+        buildLlrsNode(project, badges, locatorMeta(hints, 'Llr', 'llr', 'id')),
+        buildTestsNode(project, locatorMeta(hints, 'Test', 'test', 'name')),
+        buildSddNode(project, locatorMeta(hints, 'SddModule', 'module', 'path')),
         buildStpNode(project),
         ...buildGenericPayloadNodes(project),
     ];
+}
+
+/**
+ * Slice H: resolve `(tag, idAttr)` for the four legacy typed builders
+ * from `_ui_hints_index`, falling back to the original hard-coded
+ * pair when the hints aren't available. Lets the schema rename or
+ * re-attribute a payload (e.g. `<test>` keyed on something other than
+ * `name`) without touching this file.
+ */
+interface LeafLocatorMeta {
+    readonly tag: string;
+    readonly idAttr: string;
+}
+
+/** Exported for tier-1 tests. */
+export function locatorMeta(
+    hints: ParsedProject['_ui_hints_index'],
+    typeKey: string,
+    fallbackTag: string,
+    fallbackIdAttr: string,
+): LeafLocatorMeta {
+    const entry = hints?.[typeKey];
+    const tag = entry?.element ?? fallbackTag;
+    const idAttr = entry?.tree_node?.id_attr || fallbackIdAttr;
+    return { tag, idAttr };
+}
+
+function leafLocator(
+    meta: LeafLocatorMeta,
+    value: string,
+): RevealLocator | undefined {
+    if (!value) {
+        return undefined;
+    }
+    return meta.idAttr === 'id'
+        ? { tag: meta.tag, value }
+        : { tag: meta.tag, attr: meta.idAttr, value };
 }
 
 /**
@@ -235,6 +273,7 @@ export function _renderLabel(template: string, node: ParsedNode): string {
 function buildHlrsNode(
     project: ParsedProject,
     badges: BadgeIndex | undefined,
+    meta: LeafLocatorMeta,
 ): ProjectSpecNode {
     const sections = project.hlrs ?? [];
     const total = (project.flat_hlrs ?? []).length
@@ -263,7 +302,7 @@ function buildHlrsNode(
                             ),
                             vscode.TreeItemCollapsibleState.None,
                             undefined,
-                            { tag: 'hlr', value: h.id },
+                            leafLocator(meta, h.id),
                         );
                         applyHintsToNode(leaf, h.ui);
                         return leaf;
@@ -279,6 +318,7 @@ function buildHlrsNode(
 function buildLlrsNode(
     project: ParsedProject,
     badges: BadgeIndex | undefined,
+    meta: LeafLocatorMeta,
 ): ProjectSpecNode {
     const groups = project.llrs ?? [];
     const total = (project.flat_llrs ?? []).length
@@ -302,7 +342,7 @@ function buildLlrsNode(
                             decorate(l.id, badges?.badgeFor('llr', l.id)),
                             vscode.TreeItemCollapsibleState.None,
                             undefined,
-                            { tag: 'llr', value: l.id },
+                            leafLocator(meta, l.id),
                         );
                         applyHintsToNode(leaf, l.ui);
                         return leaf;
@@ -315,7 +355,10 @@ function buildLlrsNode(
     return node;
 }
 
-function buildTestsNode(project: ParsedProject): ProjectSpecNode {
+function buildTestsNode(
+    project: ParsedProject,
+    meta: LeafLocatorMeta,
+): ProjectSpecNode {
     const files = project.tests ?? [];
     const total = (project.flat_tests ?? []).length
         || files.reduce((n, f) => n + (f.tests?.length ?? 0), 0);
@@ -337,7 +380,7 @@ function buildTestsNode(project: ParsedProject): ProjectSpecNode {
                             t.name,
                             vscode.TreeItemCollapsibleState.None,
                             undefined,
-                            { tag: 'test', attr: 'name', value: t.name },
+                            leafLocator(meta, t.name),
                         );
                         applyHintsToNode(leaf, t.ui);
                         return leaf;
@@ -351,7 +394,10 @@ function buildTestsNode(project: ParsedProject): ProjectSpecNode {
     return node;
 }
 
-function buildSddNode(project: ParsedProject): ProjectSpecNode {
+function buildSddNode(
+    project: ParsedProject,
+    meta: LeafLocatorMeta,
+): ProjectSpecNode {
     const modules = project.sdd?.modules ?? [];
     const node = new ProjectSpecNode(
         `SDD (${modules.length} modules)`,
@@ -364,9 +410,7 @@ function buildSddNode(project: ParsedProject): ProjectSpecNode {
                     m.path ?? m.title ?? '(unnamed module)',
                     vscode.TreeItemCollapsibleState.None,
                     undefined,
-                    m.path
-                        ? { tag: 'module', attr: 'path', value: m.path }
-                        : undefined,
+                    leafLocator(meta, m.path ?? ''),
                 );
                 applyHintsToNode(leaf, m.ui);
                 return leaf;

--- a/tools/vscode-project-xml/src/util/locator.ts
+++ b/tools/vscode-project-xml/src/util/locator.ts
@@ -80,20 +80,21 @@ export function findElementRange(
 export function rangeForFinding(
     doc: vscode.TextDocument,
     finding: string,
+    registry: IdScanEntry[] = DEFAULT_ID_SCAN_REGISTRY,
 ): vscode.Range {
-    // Prefer HLR-NNN and LLR-XXX-NN tokens since they're contract ids.
-    const hlrIds = finding.match(/\bHLR-\d+\b/g) ?? [];
-    for (const id of hlrIds) {
-        const r = findIdRange(doc, 'hlr', id);
-        if (r) {
-            return r;
-        }
-    }
-    const llrIds = finding.match(/\bLLR-[A-Z0-9]+-\d+\b/g) ?? [];
-    for (const id of llrIds) {
-        const r = findIdRange(doc, 'llr', id);
-        if (r) {
-            return r;
+    // Preferred: schema-driven registry. For each registered element,
+    // scan the finding text for tokens matching its id pattern and
+    // try to range them in the document.
+    for (const entry of registry) {
+        entry.valuePattern.lastIndex = 0;
+        const matches = finding.match(entry.valuePattern) ?? [];
+        for (const value of matches) {
+            const r = entry.idAttr === 'id'
+                ? findIdRange(doc, entry.tag, value)
+                : findAttrRange(doc, entry.tag, entry.idAttr, value);
+            if (r) {
+                return r;
+            }
         }
     }
     // Quoted token — try to match it as an attribute value, then as a tag name.
@@ -121,3 +122,71 @@ export function rangeForFinding(
     // Fallback: top of file.
     return new vscode.Range(0, 0, 0, 0);
 }
+
+/**
+ * Phase 2.5b Slice G: schema-driven id-scan registry.
+ *
+ * Each entry tells `rangeForFinding` how to recognise an id token in
+ * a finding string and where to look for it in `Project.xml`:
+ *
+ *   - `tag`           lowercase XML element to scan (`hlr`, `llr`, ...)
+ *   - `idAttr`        attribute on that element holding the id
+ *   - `valuePattern`  global regex used to extract candidate values
+ *                     from the finding text
+ *
+ * `DEFAULT_ID_SCAN_REGISTRY` matches the legacy behaviour
+ * (`HLR-NNN`, `LLR-XXX-NN`). Callers (e.g. `LintDiagnosticsProvider`)
+ * can build a richer registry from `_ui_hints_index` and pass it in.
+ */
+export interface IdScanEntry {
+    readonly tag: string;
+    readonly idAttr: string;
+    readonly valuePattern: RegExp;
+}
+
+export const DEFAULT_ID_SCAN_REGISTRY: IdScanEntry[] = [
+    { tag: 'hlr', idAttr: 'id', valuePattern: /\bHLR-\d+\b/g },
+    { tag: 'llr', idAttr: 'id', valuePattern: /\bLLR-[A-Z0-9]+-\d+\b/g },
+];
+
+/**
+ * Build a finding-scan registry from the per-type entries in
+ * `_ui_hints_index`. Entries without a `tree_node` (e.g. `Document`)
+ * are skipped. The default value pattern matches dash-separated
+ * upper-case tokens like `HLR-001` or `LLR-PCL-01`; a per-tag
+ * override map lets the caller plug in tighter patterns when the
+ * generic one would over-match.
+ */
+export function buildIdScanRegistryFromHints(
+    hints:
+        | Record<string, { tree_node: { id_attr: string } | null; element: string | null }>
+        | undefined,
+    overrides: Record<string, RegExp> = DEFAULT_ID_PATTERN_OVERRIDES,
+): IdScanEntry[] {
+    if (!hints) {
+        return DEFAULT_ID_SCAN_REGISTRY;
+    }
+    const out: IdScanEntry[] = [];
+    const seen = new Set<string>();
+    for (const key of Object.keys(hints)) {
+        const entry = hints[key];
+        if (!entry?.tree_node || !entry.element) {
+            continue;
+        }
+        if (seen.has(entry.element)) {
+            continue;
+        }
+        seen.add(entry.element);
+        const idAttr = entry.tree_node.id_attr || 'id';
+        const valuePattern = overrides[entry.element]
+            ?? new RegExp('\\b[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+\\b', 'g');
+        out.push({ tag: entry.element, idAttr, valuePattern });
+    }
+    return out.length > 0 ? out : DEFAULT_ID_SCAN_REGISTRY;
+}
+
+/** Tag-specific patterns used by the default registry builder. */
+const DEFAULT_ID_PATTERN_OVERRIDES: Record<string, RegExp> = {
+    hlr: /\bHLR-\d+\b/g,
+    llr: /\bLLR-[A-Z0-9]+-\d+\b/g,
+};

--- a/tools/vscode-project-xml/test/unit/coverageCodeLens.test.ts
+++ b/tools/vscode-project-xml/test/unit/coverageCodeLens.test.ts
@@ -1,0 +1,111 @@
+// Phase 2.5b Slice F: tier-1 tests for the schema-driven lens-target
+// resolver in CoverageCodeLensProvider. Pins the seam that lets new
+// payloads with a `<ui:lens kind="coverage"/>` annotation surface
+// inline coverage lenses with no per-payload regex edits.
+
+import { strict as assert } from 'assert';
+import {
+    _RELATED_DISPATCH,
+    _SUPPORTED_LENS_KINDS,
+    getLensTargets,
+} from '../../src/codeLens/CoverageCodeLensProvider';
+import { UiHintsIndex } from '../../src/sidecar';
+
+const FULL_HINTS: UiHintsIndex = {
+    Hlr: {
+        tree_node: { label: '@id', id_attr: 'id', group: 'hlrs' },
+        form: [],
+        lenses: [{ kind: 'coverage' }, { kind: 'tracesCount' }],
+        document: false,
+        element: 'hlr',
+    },
+    Llr: {
+        tree_node: { label: '@id', id_attr: 'id', group: 'llrs' },
+        form: [],
+        lenses: [{ kind: 'coverage' }],
+        document: false,
+        element: 'llr',
+    },
+    Test: {
+        tree_node: { label: '@name', id_attr: 'name', group: 'tests' },
+        form: [],
+        lenses: [{ kind: 'tracesCount' }],
+        document: false,
+        element: 'test',
+    },
+    Document: {
+        tree_node: null,
+        form: [],
+        lenses: [],
+        document: true,
+        element: 'document',
+    },
+    SddModule: {
+        tree_node: { label: '@path', id_attr: 'path', group: 'sdd' },
+        form: [],
+        lenses: [],
+        document: false,
+        element: 'module',
+    },
+};
+
+describe('getLensTargets (Phase 2.5b Slice F)', () => {
+    it('falls back to legacy hlr/llr/test triple when hints are missing', () => {
+        const targets = getLensTargets(undefined);
+        assert.deepEqual(
+            targets.map((t) => t.element),
+            ['hlr', 'llr', 'test'],
+        );
+        assert.deepEqual(
+            targets.map((t) => t.idAttr),
+            ['id', 'id', 'name'],
+        );
+    });
+
+    it('selects only entries whose lenses include a supported kind', () => {
+        const targets = getLensTargets(FULL_HINTS);
+        const elements = targets.map((t) => t.element).sort();
+        assert.deepEqual(elements, ['hlr', 'llr', 'test']);
+        // Document has no tree_node and no lenses → skipped.
+        // SddModule has a tree_node but no supported lens → skipped.
+        for (const t of targets) {
+            assert.notEqual(t.element, 'document');
+            assert.notEqual(t.element, 'module');
+        }
+    });
+
+    it('reads idAttr from the schema tree_node, not from a hard-coded constant', () => {
+        const targets = getLensTargets(FULL_HINTS);
+        const test = targets.find((t) => t.element === 'test');
+        assert.ok(test);
+        assert.equal(test.idAttr, 'name');
+    });
+
+    it('falls back to legacy targets when the index has no supported lenses', () => {
+        const sparse: UiHintsIndex = {
+            Plan: {
+                tree_node: { label: '@version', id_attr: 'version', group: 'plan' },
+                form: [],
+                lenses: [],
+                document: false,
+                element: 'plan',
+            },
+        };
+        const targets = getLensTargets(sparse);
+        assert.deepEqual(
+            targets.map((t) => t.element),
+            ['hlr', 'llr', 'test'],
+        );
+    });
+
+    it('exposes the supported lens kinds for downstream callers', () => {
+        assert.ok(_SUPPORTED_LENS_KINDS.has('coverage'));
+        assert.ok(_SUPPORTED_LENS_KINDS.has('tracesCount'));
+        assert.equal(_SUPPORTED_LENS_KINDS.has('foo'), false);
+    });
+
+    it('keeps the per-element related dispatch table aligned with legacy elements', () => {
+        const keys = Object.keys(_RELATED_DISPATCH).sort();
+        assert.deepEqual(keys, ['hlr', 'llr', 'test']);
+    });
+});

--- a/tools/vscode-project-xml/test/unit/locatorRegistry.test.ts
+++ b/tools/vscode-project-xml/test/unit/locatorRegistry.test.ts
@@ -1,0 +1,106 @@
+// Phase 2.5b Slice G: tier-1 tests for the schema-driven id-scan
+// registry that backs `rangeForFinding`. The default registry
+// preserves the legacy HLR/LLR scan; `buildIdScanRegistryFromHints`
+// derives one from `_ui_hints_index` so payloads that the schema
+// declares get diagnostic ranges with no locator edits.
+
+import { strict as assert } from 'assert';
+import {
+    DEFAULT_ID_SCAN_REGISTRY,
+    IdScanEntry,
+    buildIdScanRegistryFromHints,
+} from '../../src/util/locator';
+
+describe('DEFAULT_ID_SCAN_REGISTRY (Phase 2.5b Slice G)', () => {
+    it('preserves the legacy HLR / LLR scan order', () => {
+        assert.equal(DEFAULT_ID_SCAN_REGISTRY.length, 2);
+        assert.equal(DEFAULT_ID_SCAN_REGISTRY[0].tag, 'hlr');
+        assert.equal(DEFAULT_ID_SCAN_REGISTRY[1].tag, 'llr');
+        assert.equal(DEFAULT_ID_SCAN_REGISTRY[0].idAttr, 'id');
+        assert.equal(DEFAULT_ID_SCAN_REGISTRY[1].idAttr, 'id');
+    });
+
+    it('matches HLR-NNN tokens', () => {
+        const re = DEFAULT_ID_SCAN_REGISTRY[0].valuePattern;
+        re.lastIndex = 0;
+        assert.deepEqual('foo HLR-001 HLR-042 bar'.match(re), ['HLR-001', 'HLR-042']);
+    });
+
+    it('matches LLR-XXX-NN tokens', () => {
+        const re = DEFAULT_ID_SCAN_REGISTRY[1].valuePattern;
+        re.lastIndex = 0;
+        assert.deepEqual(
+            'See LLR-PCL-01 and LLR-XYZ-99'.match(re),
+            ['LLR-PCL-01', 'LLR-XYZ-99'],
+        );
+    });
+});
+
+describe('buildIdScanRegistryFromHints (Phase 2.5b Slice G)', () => {
+    const hints = {
+        Hlr: {
+            tree_node: { id_attr: 'id', label: '@id', group: 'hlrs' },
+            element: 'hlr',
+        },
+        Llr: {
+            tree_node: { id_attr: 'id', label: '@id', group: 'llrs' },
+            element: 'llr',
+        },
+        Test: {
+            tree_node: { id_attr: 'name', label: '@name', group: 'tests' },
+            element: 'test',
+        },
+        Document: {
+            tree_node: null,
+            element: 'document',
+        },
+    };
+
+    it('falls back to the default registry when hints are undefined', () => {
+        assert.equal(
+            buildIdScanRegistryFromHints(undefined),
+            DEFAULT_ID_SCAN_REGISTRY,
+        );
+    });
+
+    it('emits one entry per tree_node-bearing element', () => {
+        const reg = buildIdScanRegistryFromHints(hints);
+        const tags = reg.map((e: IdScanEntry) => e.tag).sort();
+        assert.deepEqual(tags, ['hlr', 'llr', 'test']);
+    });
+
+    it('reads the schema id_attr (test → name, not id)', () => {
+        const reg = buildIdScanRegistryFromHints(hints);
+        const test = reg.find((e: IdScanEntry) => e.tag === 'test');
+        assert.ok(test);
+        assert.equal(test.idAttr, 'name');
+    });
+
+    it('uses per-tag overrides for HLR / LLR (preserving exact patterns)', () => {
+        const reg = buildIdScanRegistryFromHints(hints);
+        const hlr = reg.find((e: IdScanEntry) => e.tag === 'hlr');
+        assert.ok(hlr);
+        hlr.valuePattern.lastIndex = 0;
+        assert.deepEqual('HLR-001 LLR-XYZ-99'.match(hlr.valuePattern), ['HLR-001']);
+    });
+
+    it('uses a generic ALL-CAPS-WITH-DASHES pattern for unknown tags', () => {
+        const reg = buildIdScanRegistryFromHints(hints);
+        const test = reg.find((e: IdScanEntry) => e.tag === 'test');
+        assert.ok(test);
+        test.valuePattern.lastIndex = 0;
+        // Generic pattern: matches dash-separated upper tokens.
+        // Test names usually look like `test_foo_bar`, which the
+        // generic pattern correctly does NOT match -- the tag
+        // resolution falls through to the quoted-token / element
+        // branches in rangeForFinding.
+        assert.deepEqual('test_foo_bar'.match(test.valuePattern), null);
+    });
+
+    it('falls back to the default registry when no hints are eligible', () => {
+        const reg = buildIdScanRegistryFromHints({
+            Document: { tree_node: null, element: 'document' },
+        });
+        assert.equal(reg, DEFAULT_ID_SCAN_REGISTRY);
+    });
+});

--- a/tools/vscode-project-xml/test/unit/projectSpecProvider.test.ts
+++ b/tools/vscode-project-xml/test/unit/projectSpecProvider.test.ts
@@ -1,0 +1,184 @@
+// Phase 2.5b Slice E: tier-1 tests for the generic payload-node
+// builder in ProjectSpecProvider. Pins the seam that lets new
+// payloads (any complex type with a `<ui:treeNode/>` annotation)
+// surface in the Project Spec view without TypeScript edits.
+
+import { strict as assert } from 'assert';
+import * as vscode from 'vscode';
+import {
+    COVERED_TYPE_KEYS,
+    ProjectSpecNode,
+    _buildGenericPayloadNodes,
+    _renderLabel,
+} from '../../src/treeView/ProjectSpecProvider';
+import {
+    ParsedNode,
+    ParsedNodesIndex,
+    ParsedProject,
+    UiHintsIndex,
+} from '../../src/sidecar';
+
+const PLAN_HINT: UiHintsIndex = {
+    Plan: {
+        tree_node: { label: '@version', id_attr: 'version', group: 'plan' },
+        form: [],
+        lenses: [],
+        document: false,
+        element: 'plan',
+    },
+    'Plan/item': {
+        tree_node: { label: '@id', id_attr: 'id', group: 'plan' },
+        form: [],
+        lenses: [],
+        document: false,
+        element: 'item',
+    },
+    Hlr: {
+        tree_node: { label: '@id @name', id_attr: 'id', group: 'hlrs' },
+        form: [],
+        lenses: [],
+        document: false,
+        element: 'hlr',
+    },
+    Document: {
+        tree_node: null,
+        form: [],
+        lenses: [],
+        document: true,
+        element: 'document',
+    },
+};
+
+const PLAN_NODE: ParsedNode = {
+    tag: 'plan',
+    attrs: { version: '0.1' },
+    ui: null,
+    text: null,
+};
+
+const ITEM_NODES: ParsedNode[] = [
+    {
+        tag: 'item',
+        attrs: { id: 'P-001', status: 'done' },
+        ui: { icon: 'check' },
+        text: 'Wire list_documents.',
+    },
+    {
+        tag: 'item',
+        attrs: { id: 'P-002', status: 'open' },
+        ui: null,
+        text: 'Lens provider rewrite.',
+    },
+];
+
+function makeProject(nodes: ParsedNodesIndex): ParsedProject {
+    return {
+        name: 'TraceR',
+        schema_version: '1.4',
+        _ui_hints_index: PLAN_HINT,
+        _nodes: nodes,
+    };
+}
+
+describe('buildGenericPayloadNodes (Phase 2.5b Slice E)', () => {
+    it('skips type-keys handled by the typed builders', () => {
+        // Hlr is in COVERED_TYPE_KEYS even when present in _nodes.
+        assert.ok(COVERED_TYPE_KEYS.has('Hlr'));
+        const project = makeProject({
+            Hlr: [{ tag: 'hlr', attrs: { id: 'HLR-001' }, ui: null, text: null }],
+        });
+        assert.deepEqual(_buildGenericPayloadNodes(project), []);
+    });
+
+    it('emits a top-level group per uncovered type-key', () => {
+        const project = makeProject({
+            Plan: [PLAN_NODE],
+            'Plan/item': ITEM_NODES,
+        });
+        const groups = _buildGenericPayloadNodes(project);
+        assert.equal(groups.length, 2);
+        const labels = groups.map((g) => g.label);
+        assert.ok(labels.includes('Plan (1)'));
+        assert.ok(labels.includes('Plan/item (2)'));
+    });
+
+    it('attaches a reveal locator with the schema-declared id_attr', () => {
+        const project = makeProject({ Plan: [PLAN_NODE] });
+        const [planGroup] = _buildGenericPayloadNodes(project);
+        const child = (planGroup.children ?? [])[0];
+        assert.ok(child);
+        assert.deepEqual(child.locator, {
+            tag: 'plan',
+            attr: 'version',
+            value: '0.1',
+        });
+    });
+
+    it('renders @attr substitution from the tree_node label template', () => {
+        const project = makeProject({ 'Plan/item': ITEM_NODES });
+        const [itemGroup] = _buildGenericPayloadNodes(project);
+        const childLabels = (itemGroup.children ?? []).map((c) => c.label);
+        assert.deepEqual(childLabels, ['P-001', 'P-002']);
+    });
+
+    it('applies ui hints (icon) to generic leaf nodes', () => {
+        const project = makeProject({ 'Plan/item': ITEM_NODES });
+        const [itemGroup] = _buildGenericPayloadNodes(project);
+        const [first] = itemGroup.children ?? [];
+        assert.ok(first.iconPath instanceof vscode.ThemeIcon);
+        assert.equal((first.iconPath as vscode.ThemeIcon).id, 'check');
+    });
+
+    it('skips entries without a tree_node (e.g. Document)', () => {
+        const project = makeProject({
+            Document: [{ tag: 'document', attrs: { id: 'SDD' }, ui: null, text: null }],
+        });
+        assert.deepEqual(_buildGenericPayloadNodes(project), []);
+    });
+
+    it('returns [] when _nodes / _ui_hints_index are absent', () => {
+        const project: ParsedProject = { name: 'Legacy' };
+        assert.deepEqual(_buildGenericPayloadNodes(project), []);
+    });
+
+    it('emits an empty (None) group when a type has zero instances', () => {
+        const project = makeProject({ Plan: [] });
+        const [planGroup] = _buildGenericPayloadNodes(project);
+        assert.equal(planGroup.label, 'Plan (0)');
+        assert.equal(
+            planGroup.collapsibleState,
+            vscode.TreeItemCollapsibleState.None,
+        );
+    });
+});
+
+describe('_renderLabel (Phase 2.5b Slice E)', () => {
+    const node = (attrs: Record<string, string>): ParsedNode => ({
+        tag: 'x',
+        attrs,
+        ui: null,
+        text: null,
+    });
+
+    it('substitutes @attr tokens', () => {
+        assert.equal(_renderLabel('@id', node({ id: 'P-001' })), 'P-001');
+    });
+
+    it('joins multiple tokens', () => {
+        assert.equal(
+            _renderLabel('@id @name', node({ id: 'HLR-001', name: 'SoT' })),
+            'HLR-001 SoT',
+        );
+    });
+
+    it('drops dangling em-dash separators when a token is missing', () => {
+        assert.equal(
+            _renderLabel('@id — @name', node({ id: 'HLR-001' })),
+            'HLR-001',
+        );
+    });
+
+    it('collapses to empty string when no tokens resolve', () => {
+        assert.equal(_renderLabel('@missing', node({})), '');
+    });
+});

--- a/tools/vscode-project-xml/test/unit/projectSpecProvider.test.ts
+++ b/tools/vscode-project-xml/test/unit/projectSpecProvider.test.ts
@@ -10,6 +10,7 @@ import {
     ProjectSpecNode,
     _buildGenericPayloadNodes,
     _renderLabel,
+    locatorMeta,
 } from '../../src/treeView/ProjectSpecProvider';
 import {
     ParsedNode,
@@ -180,5 +181,53 @@ describe('_renderLabel (Phase 2.5b Slice E)', () => {
 
     it('collapses to empty string when no tokens resolve', () => {
         assert.equal(_renderLabel('@missing', node({})), '');
+    });
+});
+
+describe('locatorMeta (Phase 2.5b Slice H)', () => {
+    const hints: UiHintsIndex = {
+        Test: {
+            tree_node: { label: '@name', id_attr: 'name', group: 'tests' },
+            form: [],
+            lenses: [],
+            document: false,
+            element: 'test',
+        },
+        Hlr: {
+            tree_node: { label: '@id', id_attr: 'id', group: 'hlrs' },
+            form: [],
+            lenses: [],
+            document: false,
+            element: 'hlr',
+        },
+    };
+
+    it('reads tag + idAttr from the schema when present', () => {
+        const meta = locatorMeta(hints, 'Test', 'fallback', 'fb');
+        assert.deepEqual(meta, { tag: 'test', idAttr: 'name' });
+    });
+
+    it('falls back when the type key is absent', () => {
+        const meta = locatorMeta(hints, 'Missing', 'fallback', 'fb');
+        assert.deepEqual(meta, { tag: 'fallback', idAttr: 'fb' });
+    });
+
+    it('falls back when hints are undefined', () => {
+        const meta = locatorMeta(undefined, 'Test', 'test', 'name');
+        assert.deepEqual(meta, { tag: 'test', idAttr: 'name' });
+    });
+
+    it('falls back when the type entry has no tree_node', () => {
+        const partial: UiHintsIndex = {
+            Document: {
+                tree_node: null,
+                form: [],
+                lenses: [],
+                document: true,
+                element: 'document',
+            },
+        };
+        const meta = locatorMeta(partial, 'Document', 'document', 'id');
+        assert.deepEqual(meta, { tag: 'document', idAttr: 'id' });
     });
 });

--- a/tools/vscode-project-xml/test/unit/uiHintsIndex.test.ts
+++ b/tools/vscode-project-xml/test/unit/uiHintsIndex.test.ts
@@ -1,0 +1,105 @@
+// Phase 2.5b Slice C: tier-1 contract tests for the typed
+// `uiHintsIndex` surface on `ProjectIoClient` and the embedded
+// `_ui_hints_index` field on `ParsedProject`.
+//
+// The substantive behavioural coverage lives in the Python suite
+// (test/test_project_io.py::UiHintsIndexTests). These tests pin the
+// TypeScript wrapper: that the method exists, forwards through
+// `request()`, and returns a value typed as `UiHintsIndexResult`; and
+// that `ParsedProject._ui_hints_index` round-trips a `UiHintsIndex`.
+
+import { strict as assert } from 'assert';
+import {
+    ParsedProject,
+    ProjectIoClient,
+    UiHintEntry,
+    UiHintsIndex,
+    UiHintsIndexResult,
+} from '../../src/sidecar';
+
+class FakeClient {
+    public lastMethod: string | undefined;
+    public lastParams: Record<string, unknown> | undefined;
+    constructor(private readonly result: UiHintsIndex) {}
+    async uiHintsIndex(
+        params: Record<string, unknown> = {},
+    ): Promise<UiHintsIndexResult> {
+        this.lastMethod = 'ui_hints_index';
+        this.lastParams = params;
+        return { ui_hints_index: this.result };
+    }
+}
+
+function asClient(c: FakeClient): ProjectIoClient {
+    return c as unknown as ProjectIoClient;
+}
+
+const HLR_ENTRY: UiHintEntry = {
+    tree_node: { label: '@id', id_attr: 'id', group: 'hlrs' },
+    form: [
+        { target: 'id', kind: 'attr', field: 'text', required: true },
+        { target: 'name', kind: 'attr', field: 'text', required: false },
+        { target: 'text', kind: 'child', field: 'textarea', required: true },
+        { target: 'trace', kind: 'child', field: 'ref:HLR', required: false },
+    ],
+    lenses: [{ kind: 'coverage' }, { kind: 'tracesCount' }],
+    document: false,
+};
+
+const DOCUMENT_ENTRY: UiHintEntry = {
+    tree_node: null,
+    form: [],
+    lenses: [],
+    document: true,
+};
+
+const SAMPLE_INDEX: UiHintsIndex = {
+    Hlr: HLR_ENTRY,
+    Document: DOCUMENT_ENTRY,
+};
+
+describe('ProjectIoClient.uiHintsIndex (Phase 2.5b Slice C)', () => {
+    it('returns a typed UiHintsIndexResult', async () => {
+        const fake = new FakeClient(SAMPLE_INDEX);
+        const result = await asClient(fake).uiHintsIndex();
+        assert.equal(fake.lastMethod, 'ui_hints_index');
+        assert.deepEqual(fake.lastParams, {});
+        assert.ok(result.ui_hints_index);
+        const hlr = result.ui_hints_index['Hlr'];
+        assert.equal(hlr.tree_node?.id_attr, 'id');
+        assert.equal(hlr.form.length, 4);
+        assert.equal(hlr.lenses[0].kind, 'coverage');
+        assert.equal(hlr.document, false);
+    });
+
+    it('forwards optional xsd_path param', async () => {
+        const fake = new FakeClient(SAMPLE_INDEX);
+        await asClient(fake).uiHintsIndex({ xsd_path: '/tmp/project.xsd' });
+        assert.deepEqual(fake.lastParams, { xsd_path: '/tmp/project.xsd' });
+    });
+
+    it('round-trips Document entry with no tree node', () => {
+        const doc = SAMPLE_INDEX['Document'];
+        assert.equal(doc.tree_node, null);
+        assert.equal(doc.document, true);
+        assert.equal(doc.form.length, 0);
+    });
+});
+
+describe('ParsedProject._ui_hints_index (Phase 2.5b Slice C)', () => {
+    it('accepts an embedded UiHintsIndex without widening the type', () => {
+        const project: ParsedProject = {
+            name: 'TraceR',
+            schema_version: '1.4',
+            _ui_hints_index: SAMPLE_INDEX,
+        };
+        assert.equal(project.schema_version, '1.4');
+        assert.ok(project._ui_hints_index);
+        assert.equal(project._ui_hints_index['Hlr'].form[0].kind, 'attr');
+    });
+
+    it('treats _ui_hints_index as optional (older sidecars)', () => {
+        const project: ParsedProject = { name: 'Legacy' };
+        assert.equal(project._ui_hints_index, undefined);
+    });
+});

--- a/tools/vscode-project-xml/test/unit/uiHintsIndex.test.ts
+++ b/tools/vscode-project-xml/test/unit/uiHintsIndex.test.ts
@@ -10,6 +10,8 @@
 
 import { strict as assert } from 'assert';
 import {
+    ParsedNode,
+    ParsedNodesIndex,
     ParsedProject,
     ProjectIoClient,
     UiHintEntry,
@@ -44,6 +46,7 @@ const HLR_ENTRY: UiHintEntry = {
     ],
     lenses: [{ kind: 'coverage' }, { kind: 'tracesCount' }],
     document: false,
+    element: 'hlr',
 };
 
 const DOCUMENT_ENTRY: UiHintEntry = {
@@ -51,6 +54,7 @@ const DOCUMENT_ENTRY: UiHintEntry = {
     form: [],
     lenses: [],
     document: true,
+    element: 'document',
 };
 
 const SAMPLE_INDEX: UiHintsIndex = {
@@ -101,5 +105,45 @@ describe('ParsedProject._ui_hints_index (Phase 2.5b Slice C)', () => {
     it('treats _ui_hints_index as optional (older sidecars)', () => {
         const project: ParsedProject = { name: 'Legacy' };
         assert.equal(project._ui_hints_index, undefined);
+    });
+});
+
+describe('ParsedNode + _nodes (Phase 2.5b Slice D)', () => {
+    it('UiHintEntry exposes the bound element name', () => {
+        assert.equal(HLR_ENTRY.element, 'hlr');
+        assert.equal(DOCUMENT_ENTRY.element, 'document');
+    });
+
+    it('ParsedProject._nodes accepts a generic node index', () => {
+        const planNode: ParsedNode = {
+            tag: 'plan',
+            attrs: { version: '0.1' },
+            ui: null,
+            text: null,
+        };
+        const itemNode: ParsedNode = {
+            tag: 'item',
+            attrs: { id: 'P-001', status: 'done' },
+            ui: { icon: 'check', color: 'charts.green' },
+            text: 'Wire list_documents through the sidecar.',
+        };
+        const nodes: ParsedNodesIndex = {
+            Plan: [planNode],
+            'Plan/item': [itemNode],
+        };
+        const project: ParsedProject = {
+            name: 'TraceR',
+            schema_version: '1.4',
+            _nodes: nodes,
+        };
+        assert.ok(project._nodes);
+        assert.equal(project._nodes['Plan'].length, 1);
+        assert.equal(project._nodes['Plan/item'][0].attrs.id, 'P-001');
+        assert.equal(project._nodes['Plan/item'][0].ui?.icon, 'check');
+    });
+
+    it('treats _nodes as optional (older sidecars)', () => {
+        const project: ParsedProject = { name: 'Legacy' };
+        assert.equal(project._nodes, undefined);
     });
 });


### PR DESCRIPTION
Implements Phase 2.5b in six slices on top of the contract slice that landed in Phase 2.5. Adding a new payload to `tools/project.xsd` with a `<xs:appinfo><ui:treeNode/></xs:appinfo>` annotation now surfaces it across the VS Code extension's tree, lens, and diagnostic surfaces with **zero** TypeScript edits.

## Slices

| Slice | Commit | What it ships |
|---|---|---|
| A | `43b207a` | `xs:appinfo` UI vocabulary published in XSD; Schema_Reference §16. |
| B | `d899dba` | `parse_ui_hints_index` Python helper + `ui_hints_index` JSON-RPC method + `_ui_hints_index` embed on `parse_to_json`; `schema_version` 1.3 → 1.4. |
| C | `070c2d2` | Typed `UiHintsIndex` / `UiHintEntry` / `UiHintsIndexResult` in the TS sidecar shim + `uiHintsIndex()` wrapper. |
| D | `dcf167c` | Generic `_nodes` payload index emitted alongside `_ui_hints_index`; `UiHintEntry.element` records the bound XML tag; `ParsedNode` / `ParsedNodesIndex` in TS. Acceptance test: `<plan>` payload appears in `_nodes` with no special-casing. |
| E | `64ec089` | `ProjectSpecProvider.buildGenericPayloadNodes` walks `_nodes × _ui_hints_index` and emits one top-level group per uncovered `tree_node`-bearing type-key. `<plan>` renders in the Project Spec view automatically. |
| F | `1b828d2` | `CoverageCodeLensProvider.getLensTargets` derives `(element, idAttr)` from `_ui_hints_index` filtered to supported lens kinds (`coverage`, `tracesCount`); legacy hlr/llr/test triple becomes the fallback. |
| G+H | `8e4697c` | `buildIdScanRegistryFromHints` drives lint-diagnostic id ranging from the schema; the four typed tree builders (`buildHlrsNode` / `buildLlrsNode` / `buildTestsNode` / `buildSddNode`) read `(tag, idAttr)` from `locatorMeta(hints, typeKey, ...)` instead of literal `'hlr'`/`'llr'`/`'test'`/`'module'` blocks. |

## Verification

* Python: 69 → 72 tests (+3); lint 0E / 57W; all 5 generated docs byte-identical.
* TypeScript: 57 → 96 tests (+39); `tsc --noEmit` clean.
* JSON-RPC schema: `schema_version` bumped 1.3 → 1.4 (additive: new `_ui_hints_index` and `_nodes` fields on `parse_to_json`; new `ui_hints_index` method).
* Process: every commit refreshed `README.md` and `doc/Schema_Reference.md` per the SKILL.md Hard Rules.

## What's next

* **Phase 2.5c**: payload-agnostic Quick Fix table keyed on `Finding.code` (independent of this work; uses the same hint registry).
* **Phase 3**: form panels driven by `UiFormField[]`.

Closes #7.