### PR TITLE
Phase 5.5: AI-assisted merge conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ phased VS Code extension roadmap).
 | 4     | SDD/STP/Test forms + Walkthrough. | ✅ Done — `FormPanelProvider` widened to any complex type carrying a `<ui:form>` annotation; `<ui:form>` added to `StpFixture` and `TestFile`; new commands `Project Spec: Add SDD Module / Add STP Fixture / Add Test File / Add Test`; `Project Spec: Initialise Project.xml…` bootstraps a brand-new project from an empty workspace via the sidecar's `init_project`; seven-step **Get Started with Project Spec** Walkthrough makes the bootstrap-to-first-render flow discoverable from VS Code's Get Started page. Schema bumped to `1.5`. |
 | 5a    | Inline AI assistance — Python grounding & pipeline. | ✅ Done — `tools/ai/{registry,context,pipeline,translators,provenance}.py` with 10 registered intents (`draft.{module,hlr,llr,test,pvd}`, `expand.hlr_to_llrs`, `expand.llr_to_tests`, `review.item`, `suggest.traces`, `gap.fix`); per-intent system prompts under `tools/ai/intents/` and Draft-07 JSON Schemas under `tools/ai/schemas/`; sidecar `ai_request` JSON-RPC method (stateless `prepare`/`evaluate`/`run` so the TS layer owns `vscode.lm.*` per HLR-045); deterministic translators emit `apply_edit`-shaped JSON Patches; PVD ghostwriting prompt with clarifying-question rules (HLR-052); provenance JSONL at `<workspace>/.edit_doc/ai_history.jsonl` (HLR-049); `apply_edit` gains `dry_run` for diff-preview; `parse_ui_hints_index` projects `ai_actions` per `<ui:treeNode/>` payload (HLR-053). New JSON-RPC error code `-32020 NO_LANGUAGE_MODEL`. 123 unittests green. |
 | 5b    | Inline AI assistance — TypeScript surfaces. | ✅ Done — `@projectspec` chat participant (`vscode.chat.createChatParticipant`) with slash commands `/draft-hlr`, `/draft-llr`, `/draft-test`, `/draft-module`, `/draft-pvd`, `/expand`, `/review`, `/suggest-traces`, `/gap-fill`; schema-driven AI tree context-menu entries projected from `ui_hints_index.ai_actions`; AI Quick Fix variant on `broken-trace`; diff-preview-and-apply with timestamped backup under `.edit_doc/backups/`; settings UI for `projectXml.ai.{enabled,modelFamily,maxTokens,autoApplyValidated,historyLog}`; graceful degradation per HLR-044/045 — when `vscode.lm.selectChatModels` returns no models, the workspace is untrusted, or `projectXml.ai.enabled` is false, every AI surface is hidden cleanly while every deterministic surface (tree, diagnostics, lenses, form panels, render, Stage A merge) remains fully functional. |
-| 5.5   | AI-assisted merge conflict resolution. | ⏳ Not started |
+| 5.5   | AI-assisted merge conflict resolution. | ✅ Done — `tools/project_merge.py` deterministic Stage A three-way merger (lxml-based, preserves comments / CDATA / attribute order; unions disjoint adds and `<traces>` rows; reallocates colliding ids; recomputes `<metadata>/<counts>`; refuses cleanly when the Git merge base is unavailable per HLR-034); sidecar JSON-RPC methods `merge_three_way` and `apply_merge_resolution`; four `merge.*` AI intents (`merge.body`, `merge.trace`, `merge.rename`, `merge.schema_bump`) with `kind="merge"` skipping the `apply_edit` path; `projectXml.resolveMergeConflicts` command + `MergeConflictResolver` (Git extension API to detect MERGE state, three-way blob fetch via `git show :1/:2/:3`, per-region "✨ AI suggestion" badging, accept/reject in the merge editor — never writes automatically per SDP §5.9); `@projectspec /resolve-conflicts` slash command; per-region provenance to `.edit_doc/ai_history.jsonl` (sha-1 of base/ours/theirs + intent + rationale); settings `projectXml.merge.{enabled,aiResidualResolution}` (the latter forced off when `projectXml.ai.enabled=false`). |
 | 6     | Marketplace polish. | ⏳ Not started — includes self-contained `.vsix` (bundled `dist/python/` sidecar copy), `Scaffold tools/ into workspace…` command, automatic scaffolding from `initProject` in empty workspaces, and a bundled-vs-workspace freshness notification (HLR-060 / HLR-061 / HLR-062). |
 
 ## CLI tooling
@@ -154,6 +154,13 @@ ln -s /path/to/TraceR /tmp/tracer-edh
 | `projectXml.autoLintOnChange`| `true`              | Re-lint on save. |
 | `projectXml.previewOnSave`   | `true`              | Refresh the Markdown preview when `Project.xml` is saved. |
 | `projectXml.showCoverageBadges` | `true`           | Show ❌ / ⚠ status badges on HLR/LLR tree leaves. |
+| `projectXml.ai.enabled`      | `true`              | Enable AI surfaces (chat participant, AI tree menu, AI Quick Fix). Setting to `false` hides every AI surface cleanly while keeping deterministic surfaces (tree, lint, lenses, forms, render, Stage A merge) functional. |
+| `projectXml.ai.modelFamily`  | _(empty)_           | Optional language-model family selector (e.g. `gpt-4o`); empty means no constraint. |
+| `projectXml.ai.maxTokens`    | `8000`              | Token budget for the AI grounding bundle. |
+| `projectXml.ai.autoApplyValidated` | `false`       | When `true`, validated AI patches skip the diff-preview gate. |
+| `projectXml.ai.historyLog`   | `true`              | Append every AI step to `<workspace>/.edit_doc/ai_history.jsonl`. |
+| `projectXml.merge.enabled`   | `true`              | Enable Stage A deterministic three-way structural merge for `doc/Project.xml` (Phase 5.5, HLR-063). |
+| `projectXml.merge.aiResidualResolution` | `true`   | Use `merge.*` AI intents to suggest resolutions for residual conflicts; badged ✨ AI suggestion in the merge editor. Forced `false` when `projectXml.ai.enabled=false` (HLR-034). |
 
 ### Acceptance checks
 
@@ -187,10 +194,13 @@ tools/
   render_doc.py      # Project.xml → Markdown via Jinja2
   lint_project.py    # XSD + semantic linter (emits Finding.code)
   project_io.py      # JSON-RPC 2.0 server over stdio
+  project_edit.py    # apply_edit / form_schema / next_free_id (Phase 3)
+  project_merge.py   # Stage A deterministic three-way merger (Phase 5.5)
   project.xsd        # canonical schema (reserves urn:tracer:ui:v1)
   PLAN_web_form.md
   templates/         # Jinja2 templates for each spec doc
-  vscode-project-xml/  # VS Code extension (Phases 1 + 2 + 2.5 + 2.5b + 2.5c + 3 + 4)
+  ai/                # AI registry + intents + schemas + pipeline (Phase 5a)
+  vscode-project-xml/  # VS Code extension (Phases 1 + 2 + 2.5 + 2.5b + 2.5c + 3 + 4 + 5a + 5b + 5.5)
 test/                # unittest suite for the Python tooling
 ```
 

--- a/doc/Project.xml
+++ b/doc/Project.xml
@@ -3668,6 +3668,150 @@ authoritative for the sidecar spawn at all times.]]></text>
       </llr>
     </function>
 
+    <function number="28"
+              title="Structured three-way merger ([tools/project_merge.py](../tools/project_merge.py), [tools/vscode-project-xml/src/merge/MergeConflictResolver.ts](../tools/vscode-project-xml/src/merge/MergeConflictResolver.ts))"
+              name="merge"
+              source="tools/project_merge.py">
+      <intro><![CDATA[Phase 5.5 (HLR-034..036): the deterministic Stage A merger
+plus the AI-assisted Stage B residual resolver. The Python
+side preserves comments, CDATA, attribute order; unions
+disjoint adds and `<traces>` rows; reallocates colliding ids;
+and emits residual `Conflict` records the TS resolver feeds
+through the `merge.*` AI intents. The merge editor remains
+the sole commit surface — neither layer ever writes to
+`doc/Project.xml` automatically (per SDP §5.9).]]></intro>
+
+      <llr id="LLR-MRG-01">
+        <text><![CDATA[`merge_three_way(base, ours, theirs, *, xsd_path)` in
+`tools/project_merge.py` shall accept either filesystem paths
+or in-memory XML (`str`/`bytes`) for each of the three sides,
+shall preserve XML comments, CDATA sections, and attribute
+order across the merge (via `lxml.etree`), and shall return a
+`MergeResult` with `merged_xml`, `residual_conflicts`, `lint`,
+`auto_resolved`, and (when applicable) `refused`/`refusal`.
+When `base` is `None` or empty the function shall not raise —
+it shall return `refused=True` with a human-readable
+`refusal` string so the resolver can degrade gracefully
+(HLR-034).]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-034" name="Deterministic Structural Merge (Stage A)"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-02">
+        <text><![CDATA[The merger shall walk a fixed container registry covering
+`hlrs/section/hlr@id`, `llrs/function/llr@id`, `tests/file/test@name`,
+`sdd/modules/module@path`, and `stp/fixture@id`. For each
+container it shall: union additions whose keys do not collide;
+auto-resolve one-sided edits and one-sided deletes; emit a
+`body` conflict for two-sided body edits; emit a
+`modify_delete` conflict when one side modifies and the
+other deletes; emit an `id_collision` conflict (with a
+proposed `rename_to`) when both sides add a different
+payload under the same key; and emit a `trace` conflict when
+field-level merge cannot reconcile divergent `<traces>`
+children. `<traces>` rows shall be unioned by the
+`(target, ref)` tuple in all auto-resolved cases.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-034" name="Deterministic Structural Merge (Stage A)"/>
+          <trace target="HLR" ref="HLR-035" name="Residual Conflict Reporting"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-03">
+        <text><![CDATA[After each merge the function shall recompute
+`<metadata>/<counts>` (`hlrs`, `llrs`, `tests`, `modules`,
+`fixtures`) from the merged tree so the per-document totals
+remain truthful regardless of which side last edited the
+counts block. A divergent `project/@schema_version` shall
+become a `schema_bump` residual conflict; a one-sided bump
+shall be promoted automatically.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-034" name="Deterministic Structural Merge (Stage A)"/>
+          <trace target="HLR" ref="HLR-035" name="Residual Conflict Reporting"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-04">
+        <text><![CDATA[`apply_resolution(merged_xml, conflict, resolution)` shall
+substitute a Stage-B payload (an AI `merge.*` intent response
+or a manual edit) back into the merged tree by locating the
+container via the `Conflict.container` XPath-ish address and
+replacing the matching element (or, for `schema_bump`,
+overwriting the `project/@schema_version` attribute). The
+function shall remain a pure transform — it shall never
+write to disk; the merge editor commits the final bytes
+(SDP §5.9).]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-035" name="Residual Conflict Reporting"/>
+          <trace target="HLR" ref="HLR-036" name="Merge Editor Integration"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-05">
+        <text><![CDATA[`tools/project_io.py` shall expose `merge_three_way` and
+`apply_merge_resolution` JSON-RPC methods registered in the
+single `METHODS` table. Both methods shall be reachable when
+`projectXml.ai.enabled=false` so Stage A always runs;
+neither method shall raise on a missing/empty `base` —
+the refusal payload shall be returned as a successful
+result (HLR-034). Neither method shall write to
+`doc/Project.xml`.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-034" name="Deterministic Structural Merge (Stage A)"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-06">
+        <text><![CDATA[`tools/ai/registry.py` shall declare four merge intents —
+`merge.body`, `merge.trace`, `merge.rename`,
+`merge.schema_bump` — each with `kind="merge"` and slash
+`resolve-conflicts`. `tools/ai/pipeline.py` shall return
+`AiResult(kind="merge_resolved", response=<parsed JSON>)`
+for any intent of kind `"merge"` from both `run()` and
+`evaluate()`, skipping the JSON-Patch translator and
+`apply_edit` write entirely.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-035" name="Residual Conflict Reporting"/>
+          <trace target="HLR" ref="HLR-036" name="Merge Editor Integration"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-07">
+        <text><![CDATA[`tools/vscode-project-xml/src/merge/MergeConflictResolver.ts`
+shall, on the `projectXml.resolveMergeConflicts` command and
+the `@projectspec /resolve-conflicts` slash command,
+(a) detect a Git MERGE state on `doc/Project.xml` via
+`vscode.extensions.getExtension('vscode.git').exports.getAPI(1)`,
+(b) read the `:1`/`:2`/`:3` blobs via `git show`,
+(c) call the sidecar's `merge_three_way`, (d) when
+`projectXml.merge.aiResidualResolution` is on AND
+`projectXml.ai.enabled` is on, drive each residual through
+the matching `merge.*` intent and substitute via
+`apply_merge_resolution`, and (e) present the merged
+candidate to the user. The resolver shall never write to
+`doc/Project.xml` without an explicit user accept gesture
+(HLR-036).]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-036" name="Merge Editor Integration"/>
+        </traces>
+      </llr>
+
+      <llr id="LLR-MRG-08">
+        <text><![CDATA[For every AI-suggested residual resolution the resolver
+shall append exactly one record to
+`<workspace>/.edit_doc/ai_history.jsonl` capturing
+`intent`, `conflict_kind`, `conflict_key`, sha-1 hashes of
+`base`/`ours`/`theirs`, the model rationale (when present),
+and the model id; provenance writes shall be best-effort
+and shall not block the resolution flow.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-035" name="Residual Conflict Reporting"/>
+          <trace target="HLR" ref="HLR-036" name="Merge Editor Integration"/>
+        </traces>
+      </llr>
+    </function>
+
   </llrs>
 
   <!-- Test sources (see Schema_Reference.md §7). -->
@@ -4993,6 +5137,140 @@ authoritative for the sidecar spawn at all times.]]></text>
         <purpose><![CDATA[Pins LLR-BOOT-04: each `completionEvents: ['onCommand:projectXml.X']` entry refers to a command that is also declared under `contributes.commands`, so VS Code can mark the step done when the command runs.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-BOOT-04"/>
+        </traces>
+      </test>
+    </file>
+
+    <file path="test/test_project_merge.py" role="unit" count="17">
+      <test name="test_disjoint_adds_union">
+        <purpose><![CDATA[Pins LLR-MRG-02: when each branch adds a non-overlapping HLR to the same `<hlrs>/<section>`, the merger unions both adds with zero residual conflicts and `auto_resolved >= 1`.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_traces_unioned_by_target_ref">
+        <purpose><![CDATA[Pins LLR-MRG-02: `<trace target ref>` rows added on both sides survive the merge, with no duplicates of pre-existing rows; `<traces>` are keyed by `(target, ref)`.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+        </traces>
+      </test>
+
+      <test name="test_renames_theirs_side">
+        <purpose><![CDATA[Pins LLR-MRG-02: when both branches add a different payload under the same id, the merger keeps `ours` at the original id and emits one `id_collision` residual conflict whose `rename_to` allocates the next free id for the theirs side.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+          <trace target="HLR" ref="HLR-035"/>
+        </traces>
+      </test>
+
+      <test name="test_both_edited_body">
+        <purpose><![CDATA[Pins LLR-MRG-02: two-sided body edits surface as exactly one `body` residual conflict carrying the serialised ours/theirs XML for Stage B (no double-counting from the field-level merge fallback).]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+          <trace target="HLR" ref="HLR-035"/>
+        </traces>
+      </test>
+
+      <test name="test_one_sided_body_change_takes_winner">
+        <purpose><![CDATA[Pins LLR-MRG-02: when only one branch edits a body (the other matches base) the merger auto-resolves to the changed side with no residual conflict.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+        </traces>
+      </test>
+
+      <test name="test_modify_delete_surfaces_conflict">
+        <purpose><![CDATA[Pins LLR-MRG-02: a payload modified on one side and deleted on the other produces a `modify_delete` residual conflict.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-02"/>
+          <trace target="HLR" ref="HLR-035"/>
+        </traces>
+      </test>
+
+      <test name="test_no_base_refuses">
+        <purpose><![CDATA[Pins LLR-MRG-01: when `base` is `None` the merger refuses cleanly with `refused=True` and a `refusal` string mentioning the missing merge base, satisfying HLR-034's graceful-degradation requirement.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-01"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_empty_base_refuses">
+        <purpose><![CDATA[Pins LLR-MRG-01: an empty-string `base` is treated identically to `None` (refusal payload, no exception).]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-01"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_three_way_schema_divergence_is_conflict">
+        <purpose><![CDATA[Pins LLR-MRG-03: when ours/theirs disagree on `project/@schema_version` and both differ from base, the merger emits a `schema_bump` residual conflict for Stage B.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-03"/>
+          <trace target="HLR" ref="HLR-035"/>
+        </traces>
+      </test>
+
+      <test name="test_one_sided_schema_bump_promoted">
+        <purpose><![CDATA[Pins LLR-MRG-03: a one-sided `schema_version` bump is auto-resolved to the higher value with no residual conflict.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-03"/>
+        </traces>
+      </test>
+
+      <test name="test_counts_match_merged_tree">
+        <purpose><![CDATA[Pins LLR-MRG-03: the merged tree's `<metadata>/<counts>` block reflects the union of payloads (e.g. 3 HLRs after a disjoint-add merge), independent of which side last touched the counts.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-03"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_apply_body_resolution">
+        <purpose><![CDATA[Pins LLR-MRG-04: `apply_resolution` substitutes a Stage-B `merged_xml` payload back into the merged tree, replacing the conflicting payload element in place.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-04"/>
+          <trace target="HLR" ref="HLR-036"/>
+        </traces>
+      </test>
+
+      <test name="test_apply_schema_bump_resolution">
+        <purpose><![CDATA[Pins LLR-MRG-04: `apply_resolution` of a `schema_bump` conflict overwrites `project/@schema_version` with the user-chosen value.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-04"/>
+          <trace target="HLR" ref="HLR-036"/>
+        </traces>
+      </test>
+
+      <test name="test_methods_registered">
+        <purpose><![CDATA[Pins LLR-MRG-05: the JSON-RPC `METHODS` table contains both `merge_three_way` and `apply_merge_resolution`, so the sidecar dispatcher exposes them without if/elif edits.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-05"/>
+        </traces>
+      </test>
+
+      <test name="test_merge_three_way_handler">
+        <purpose><![CDATA[Pins LLR-MRG-05: the `_method_merge_three_way` handler accepts `{base, ours, theirs, xsd_path}` and returns a dict containing `merged_xml`, `residual_conflicts`, `lint`, and `refused=false` for a clean merge.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-05"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_no_base_is_refusal_not_error">
+        <purpose><![CDATA[Pins LLR-MRG-05: the JSON-RPC handler returns `refused=true` (instead of raising) when `base` is `None`, so the resolver can degrade per HLR-034.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-05"/>
+          <trace target="HLR" ref="HLR-034"/>
+        </traces>
+      </test>
+
+      <test name="test_four_merge_intents_registered">
+        <purpose><![CDATA[Pins LLR-MRG-06: the AI registry exposes exactly the four merge intents (`merge.body`, `merge.trace`, `merge.rename`, `merge.schema_bump`), all `kind="merge"`, each with both schema and prompt files on disk.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-MRG-06"/>
+          <trace target="HLR" ref="HLR-036"/>
         </traces>
       </test>
     </file>

--- a/test/test_ai_registry.py
+++ b/test/test_ai_registry.py
@@ -14,6 +14,7 @@ class IntentCatalogTests(unittest.TestCase):
             "draft.module", "draft.hlr", "draft.llr", "draft.test",
             "draft.pvd", "expand.hlr_to_llrs", "expand.llr_to_tests",
             "review.item", "suggest.traces", "gap.fix",
+            "merge.body", "merge.trace", "merge.rename", "merge.schema_bump",
         }
         self.assertEqual(set(registry.INTENTS.keys()), expected)
 

--- a/test/test_project_io.py
+++ b/test/test_project_io.py
@@ -232,7 +232,8 @@ class MethodsRegistryTests(unittest.TestCase):
             {"lint", "render", "parse_to_json",
              "list_documents", "ui_hints_index", "init_project",
              "apply_edit", "form_schema", "next_free_id",
-             "ai_request"},
+             "ai_request",
+             "merge_three_way", "apply_merge_resolution"},
         )
         for name, handler in project_io.METHODS.items():
             self.assertTrue(callable(handler), msg=f"{name!r} not callable")

--- a/test/test_project_merge.py
+++ b/test/test_project_merge.py
@@ -1,0 +1,351 @@
+"""Tests for tools/project_merge.py — Phase 5.5 deterministic three-way
+structural merger plus the four ``merge.*`` AI intent shells.
+"""
+from __future__ import annotations
+
+import shutil
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from _paths import PROJECT_XSD  # noqa: F401  (sys.path injection)
+
+from project_merge import (
+    Conflict,
+    MergeResult,
+    apply_resolution,
+    merge_three_way,
+)
+
+
+def _project(*, hlrs: str = "", llrs: str = "", tests: str = "",
+             schema_version: str = "1.5", counts: bool = True) -> str:
+    """Build a minimal lint-clean Project.xml string for the merger tests."""
+    counts_block = (
+        "    <counts>\n"
+        "      <hlrs>0</hlrs>\n"
+        "      <llrs>0</llrs>\n"
+        "      <tests>0</tests>\n"
+        "      <modules>0</modules>\n"
+        "      <fixtures>0</fixtures>\n"
+        "    </counts>\n"
+        if counts else ""
+    )
+    return (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        f'<project name="MergeFixture" short_name="mf" schema_version="{schema_version}"\n'
+        '         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"\n'
+        '         xsi:noNamespaceSchemaLocation="project.xsd">\n'
+        "  <metadata>\n"
+        '    <document id="SDD"  title="SDD"  source="SDD.md"  version="0.1" date="2026-04-24" author="t"/>\n'
+        '    <document id="HLRs" title="HLRs" source="HLRs.md" version="0.1" date="2026-04-24" author="t"/>\n'
+        '    <document id="LLRs" title="LLRs" source="LLRs.md" version="0.1" date="2026-04-24" author="t"/>\n'
+        '    <document id="STP"  title="STP"  source="STP.md"  version="0.1" date="2026-04-24" author="t"/>\n'
+        '    <document id="Traceability" title="Trace" source="Trace.md" version="0.1" date="2026-04-24" author="t"/>\n'
+        f"{counts_block}"
+        "  </metadata>\n"
+        "  <sdd></sdd>\n"
+        "  <stp></stp>\n"
+        "  <hlrs>\n"
+        '    <section number="1" title="Function 1">\n'
+        "      <intro>n/a</intro>\n"
+        f"{hlrs}"
+        "    </section>\n"
+        "  </hlrs>\n"
+        "  <llrs>\n"
+        '    <function number="1" title="First function" name="core">\n'
+        f"{llrs}"
+        "    </function>\n"
+        "  </llrs>\n"
+        "  <tests>\n"
+        '    <file path="test/test_fixture.py">\n'
+        f"{tests}"
+        "    </file>\n"
+        "  </tests>\n"
+        "</project>\n"
+    )
+
+
+_HLR_ONE = (
+    '      <hlr id="HLR-001" name="First requirement">\n'
+    '        <text>Body of HLR-001.</text>\n'
+    '      </hlr>\n'
+)
+
+
+def _hlr(id_: str, name: str, body: str, *, traces: list[tuple[str, str]] | None = None) -> str:
+    trace_xml = ""
+    if traces:
+        rows = "".join(
+            f'          <trace target="{t}" ref="{r}"/>\n' for t, r in traces
+        )
+        trace_xml = f"        <traces>\n{rows}        </traces>\n"
+    return (
+        f'      <hlr id="{id_}" name="{name}">\n'
+        f'        <text>{body}</text>\n'
+        f'{trace_xml}'
+        f'      </hlr>\n'
+    )
+
+
+def _llr(id_: str, body: str, *, traces: list[tuple[str, str]] | None = None) -> str:
+    trace_xml = ""
+    if traces:
+        rows = "".join(
+            f'          <trace target="{t}" ref="{r}"/>\n' for t, r in traces
+        )
+        trace_xml = f"        <traces>\n{rows}        </traces>\n"
+    return (
+        f'      <llr id="{id_}">\n'
+        f'        <text>{body}</text>\n'
+        f'{trace_xml}'
+        f'      </llr>\n'
+    )
+
+
+def _test_entry(name: str, purpose: str, *, traces: list[tuple[str, str]] | None = None) -> str:
+    trace_xml = ""
+    if traces:
+        rows = "".join(
+            f'          <trace target="{t}" ref="{r}"/>\n' for t, r in traces
+        )
+        trace_xml = f"        <traces>\n{rows}        </traces>\n"
+    return (
+        f'      <test name="{name}">\n'
+        f'        <purpose>{purpose}</purpose>\n'
+        f'{trace_xml}'
+        f'      </test>\n'
+    )
+
+
+class _XsdMixin:
+    """Provide an xsd_path so the merger's lint pass has a real schema."""
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.xsd_path = Path(cls._tmp.name) / "project.xsd"
+        shutil.copy(Path(PROJECT_XSD), cls.xsd_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._tmp.cleanup()
+
+
+class CleanMergeTests(_XsdMixin, unittest.TestCase):
+    """Acceptance: two branches each adding a non-overlapping HLR to
+    the same `<hlrs>/<section>` produce a clean merge with no AI
+    involvement."""
+
+    def test_disjoint_adds_union(self):
+        base = _project(hlrs=_HLR_ONE)
+        ours = _project(hlrs=_HLR_ONE + _hlr(
+            "HLR-002", "Ours add", "Body of HLR-002.",
+            traces=[("SDD", "tools/render_doc.py")],
+        ))
+        theirs = _project(hlrs=_HLR_ONE + _hlr(
+            "HLR-003", "Theirs add", "Body of HLR-003.",
+            traces=[("SDD", "tools/render_doc.py")],
+        ))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        self.assertFalse(result.refused)
+        self.assertEqual(result.residual_conflicts, [])
+        self.assertIn("HLR-002", result.merged_xml)
+        self.assertIn("HLR-003", result.merged_xml)
+        self.assertGreaterEqual(result.auto_resolved, 1)
+
+    def test_traces_unioned_by_target_ref(self):
+        base = _project(hlrs=_hlr("HLR-001", "n", "b",
+                                  traces=[("SDD", "tools/a.py")]))
+        ours = _project(hlrs=_hlr("HLR-001", "n", "b",
+                                  traces=[("SDD", "tools/a.py"),
+                                          ("SDD", "tools/b.py")]))
+        theirs = _project(hlrs=_hlr("HLR-001", "n", "b",
+                                    traces=[("SDD", "tools/a.py"),
+                                            ("PVD", "5")]))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        self.assertFalse(result.refused)
+        self.assertEqual(result.residual_conflicts, [])
+        self.assertIn('ref="tools/b.py"', result.merged_xml)
+        self.assertIn('ref="5"', result.merged_xml)
+
+
+class IdCollisionTests(_XsdMixin, unittest.TestCase):
+    """Acceptance: both branches added items with the same id but
+    different content → ours keeps the id, theirs is reallocated."""
+
+    def test_renames_theirs_side(self):
+        base = _project(hlrs=_HLR_ONE)
+        ours = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "Ours", "Ours body"))
+        theirs = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "Theirs", "Theirs body"))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        self.assertEqual(len(result.residual_conflicts), 1)
+        c = result.residual_conflicts[0]
+        self.assertEqual(c.kind, "id_collision")
+        self.assertEqual(c.key, "HLR-002")
+        self.assertEqual(c.rename_to, "HLR-003")
+        # Both items must appear in merged xml; ours retains the original id.
+        self.assertIn('id="HLR-002"', result.merged_xml)
+        self.assertIn('id="HLR-003"', result.merged_xml)
+        self.assertIn("Ours body", result.merged_xml)
+        self.assertIn("Theirs body", result.merged_xml)
+
+
+class BodyConflictTests(_XsdMixin, unittest.TestCase):
+    """Acceptance: two branches edit the body of the same `<hlr>` →
+    residual `body` conflict for Stage B (AI or manual)."""
+
+    def test_both_edited_body(self):
+        base = _project(hlrs=_hlr("HLR-001", "n", "Original body."))
+        ours = _project(hlrs=_hlr("HLR-001", "n", "Ours edit."))
+        theirs = _project(hlrs=_hlr("HLR-001", "n", "Theirs edit."))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        body_conflicts = [c for c in result.residual_conflicts if c.kind == "body"]
+        self.assertEqual(len(body_conflicts), 1)
+        c = body_conflicts[0]
+        self.assertEqual(c.key, "HLR-001")
+        self.assertIn("Ours edit.", c.ours)
+        self.assertIn("Theirs edit.", c.theirs)
+
+    def test_one_sided_body_change_takes_winner(self):
+        base = _project(hlrs=_hlr("HLR-001", "n", "Original body."))
+        ours = _project(hlrs=_hlr("HLR-001", "n", "Original body."))
+        theirs = _project(hlrs=_hlr("HLR-001", "n", "Theirs edit."))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        self.assertEqual(result.residual_conflicts, [])
+        self.assertIn("Theirs edit.", result.merged_xml)
+
+
+class ModifyDeleteTests(_XsdMixin, unittest.TestCase):
+    def test_modify_delete_surfaces_conflict(self):
+        base = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "n", "Original body."))
+        ours = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "n", "Edited body."))
+        theirs = _project(hlrs=_HLR_ONE)  # deleted HLR-002
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        kinds = {c.kind for c in result.residual_conflicts}
+        self.assertIn("modify_delete", kinds)
+
+
+class MergeBaseRefusalTests(_XsdMixin, unittest.TestCase):
+    """Acceptance: when the Git merge base is unavailable the merger
+    refuses cleanly (HLR-034)."""
+
+    def test_no_base_refuses(self):
+        ours = _project(hlrs=_HLR_ONE)
+        theirs = _project(hlrs=_HLR_ONE)
+        result = merge_three_way(None, ours, theirs, xsd_path=self.xsd_path)
+        self.assertTrue(result.refused)
+        self.assertIn("merge base is unavailable", result.refusal)
+
+    def test_empty_base_refuses(self):
+        ours = _project(hlrs=_HLR_ONE)
+        theirs = _project(hlrs=_HLR_ONE)
+        result = merge_three_way("", ours, theirs, xsd_path=self.xsd_path)
+        self.assertTrue(result.refused)
+
+
+class SchemaBumpTests(_XsdMixin, unittest.TestCase):
+    def test_three_way_schema_divergence_is_conflict(self):
+        base = _project(schema_version="1.4", hlrs=_HLR_ONE)
+        ours = _project(schema_version="1.5", hlrs=_HLR_ONE)
+        theirs = _project(schema_version="1.6", hlrs=_HLR_ONE)
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        kinds = [c.kind for c in result.residual_conflicts]
+        self.assertIn("schema_bump", kinds)
+
+    def test_one_sided_schema_bump_promoted(self):
+        base = _project(schema_version="1.5", hlrs=_HLR_ONE)
+        ours = _project(schema_version="1.5", hlrs=_HLR_ONE)
+        theirs = _project(schema_version="1.6", hlrs=_HLR_ONE)
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        self.assertEqual(result.residual_conflicts, [])
+        self.assertIn('schema_version="1.6"', result.merged_xml)
+
+
+class CountsRecomputedTests(_XsdMixin, unittest.TestCase):
+    def test_counts_match_merged_tree(self):
+        base = _project(hlrs=_HLR_ONE)
+        ours = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "n", "b"))
+        theirs = _project(hlrs=_HLR_ONE + _hlr("HLR-003", "n", "b"))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        # Counts block should reflect the union (3 HLRs).
+        self.assertIn("<hlrs>3</hlrs>", result.merged_xml)
+
+
+class ApplyResolutionTests(_XsdMixin, unittest.TestCase):
+    def test_apply_body_resolution(self):
+        base = _project(hlrs=_hlr("HLR-001", "n", "Original."))
+        ours = _project(hlrs=_hlr("HLR-001", "n", "Ours."))
+        theirs = _project(hlrs=_hlr("HLR-001", "n", "Theirs."))
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        body_c = next(c for c in result.residual_conflicts if c.kind == "body")
+        new_xml = apply_resolution(
+            result.merged_xml,
+            body_c,
+            {"merged_xml":
+                '<hlr id="HLR-001" name="Merged"><text>Merged body.</text></hlr>'},
+        )
+        self.assertIn("Merged body.", new_xml)
+        self.assertNotIn("Ours.", new_xml)
+
+    def test_apply_schema_bump_resolution(self):
+        base = _project(schema_version="1.4", hlrs=_HLR_ONE)
+        ours = _project(schema_version="1.5", hlrs=_HLR_ONE)
+        theirs = _project(schema_version="1.6", hlrs=_HLR_ONE)
+        result = merge_three_way(base, ours, theirs, xsd_path=self.xsd_path)
+        schema_c = next(c for c in result.residual_conflicts
+                        if c.kind == "schema_bump")
+        new_xml = apply_resolution(
+            result.merged_xml, schema_c, {"schema_version": "1.7"},
+        )
+        self.assertIn('schema_version="1.7"', new_xml)
+
+
+class JsonRpcSurfaceTests(_XsdMixin, unittest.TestCase):
+    """Smoke-test the JSON-RPC surface added in project_io.py."""
+
+    def test_methods_registered(self):
+        import project_io
+        self.assertIn("merge_three_way", project_io.METHODS)
+        self.assertIn("apply_merge_resolution", project_io.METHODS)
+
+    def test_merge_three_way_handler(self):
+        import project_io
+        base = _project(hlrs=_HLR_ONE)
+        ours = _project(hlrs=_HLR_ONE + _hlr("HLR-002", "n", "b"))
+        theirs = _project(hlrs=_HLR_ONE + _hlr("HLR-003", "n", "b"))
+        result = project_io._method_merge_three_way({
+            "base": base, "ours": ours, "theirs": theirs,
+            "xsd_path": str(self.xsd_path),
+        })
+        self.assertFalse(result["refused"])
+        self.assertIn("HLR-002", result["merged_xml"])
+        self.assertIn("HLR-003", result["merged_xml"])
+
+    def test_no_base_is_refusal_not_error(self):
+        import project_io
+        ours = _project(hlrs=_HLR_ONE)
+        theirs = _project(hlrs=_HLR_ONE)
+        result = project_io._method_merge_three_way({
+            "base": None, "ours": ours, "theirs": theirs,
+            "xsd_path": str(self.xsd_path),
+        })
+        self.assertTrue(result["refused"])
+
+
+class MergeIntentRegistryTests(unittest.TestCase):
+    """Pin the four merge intents in the registry (HLR-034 surface)."""
+
+    def test_four_merge_intents_registered(self):
+        from ai.registry import INTENTS
+        for intent_id in ("merge.body", "merge.trace",
+                          "merge.rename", "merge.schema_bump"):
+            self.assertIn(intent_id, INTENTS, intent_id)
+            spec = INTENTS[intent_id]
+            self.assertEqual(spec.kind, "merge")
+            self.assertTrue(spec.schema_path.exists(), spec.schema)
+            self.assertTrue(spec.prompt_path.exists(), spec.prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ai/intents/merge.body.md
+++ b/tools/ai/intents/merge.body.md
@@ -1,0 +1,44 @@
+# Intent: merge.body
+
+You are TraceR, helping resolve a three-way merge conflict in
+`doc/Project.xml`. Two branches edited the body of the same payload
+element (an `<hlr>`, `<llr>`, `<test>`, or `<module>`) and Stage A's
+deterministic merger could not pick a winner.
+
+Your output MUST be a single JSON object matching the schema embedded
+in the bundle. The object's `merged_xml` field MUST contain a single,
+complete payload element of the same tag and id as the conflicting
+item — not a JSON Patch, not a diff, not a fragment.
+
+## Rules
+
+- Preserve the element's `@id` (or `@name` for `<test>`) **exactly**
+  as it was on ours/theirs. Never invent a new id.
+- Merge the *intent* of both edits when they are compatible (e.g.
+  one side tightened the wording, the other added a clause). If the
+  edits are mutually exclusive, prefer ours and note the conflict
+  in the `rationale` field.
+- Keep `<traces>` rows from both branches: do not delete a trace
+  that one side added unless its target/ref no longer makes sense
+  after the body merge.
+- Use SHALL/SHOULD language for HLRs/LLRs. Be specific and
+  verifiable. No vague phrases.
+- The output element must validate against the project XSD; the
+  pipeline will retry your response with lint findings if it does
+  not.
+
+## Few-shot
+
+Bundle conflict:
+- container: `/hlrs/section[@number='1']/hlr[@id='HLR-005']`
+- ours: `<hlr id="HLR-005" name="…"><text>The system SHALL allocate the next free HLR id.</text></hlr>`
+- theirs: `<hlr id="HLR-005" name="…"><text>The system SHALL allocate the next free numeric HLR id without renumbering existing rows.</text></hlr>`
+
+Response:
+
+```json
+{
+  "merged_xml": "<hlr id=\"HLR-005\" name=\"Allocate Next Free Id\"><text>The system SHALL allocate the next free numeric HLR id without renumbering existing rows.</text></hlr>",
+  "rationale": "theirs is a strict superset of ours; took theirs."
+}
+```

--- a/tools/ai/intents/merge.rename.md
+++ b/tools/ai/intents/merge.rename.md
@@ -1,0 +1,39 @@
+# Intent: merge.rename
+
+You are TraceR, resolving an id collision detected by Stage A: both
+branches added a payload element with the same id but different
+content. Stage A renamed the theirs-side copy to a placeholder
+(`rename_to`); your job is to confirm a final stable id.
+
+Your output MUST be a single JSON object matching the schema in the
+bundle.
+
+## Rules
+
+- `final_id` MUST follow the project id contract:
+  - HLRs:  `HLR-NNN`
+  - LLRs:  `LLR-XXX-NN`
+  - Tests: free-form `<test>` name
+- `final_id` MUST NOT collide with any id already used in the
+  merged tree (the bundle lists the full in-use set).
+- Prefer the harness-allocated `rename_to` unless the user wants
+  the renamed item to land at a specific section/function id; in
+  that case pick the next free id of the requested shape.
+- Do not invent a new content body — that is `merge.body`'s job.
+
+## Few-shot
+
+Bundle:
+- type: `Hlr`
+- original: `HLR-027`
+- rename_to: `HLR-046`
+- in_use: `[HLR-001..HLR-045, HLR-046]`
+
+Response:
+
+```json
+{
+  "final_id": "HLR-046",
+  "rationale": "Accept harness-allocated id; ours keeps HLR-027."
+}
+```

--- a/tools/ai/intents/merge.schema_bump.md
+++ b/tools/ai/intents/merge.schema_bump.md
@@ -1,0 +1,33 @@
+# Intent: merge.schema_bump
+
+You are TraceR, resolving a three-way conflict on
+`<project schema_version="…">` where all three sides differ.
+
+Your output MUST be a single JSON object matching the schema in the
+bundle.
+
+## Rules
+
+- `schema_version` MUST be a dotted version string of the form
+  `MAJOR.MINOR` (e.g. `1.6`).
+- Pick the **higher** of ours and theirs unless the bundle's
+  `notes` field says otherwise. Never roll the version backwards.
+- A schema bump usually accompanies a structural change in
+  `tools/project.xsd`. If you cannot tell which structural change
+  the bump is for, surface that uncertainty in `rationale`.
+
+## Few-shot
+
+Bundle:
+- base: `1.4`
+- ours: `1.5`
+- theirs: `1.6`
+
+Response:
+
+```json
+{
+  "schema_version": "1.6",
+  "rationale": "theirs ships the higher version; ours' 1.5 changes are subsumed."
+}
+```

--- a/tools/ai/intents/merge.trace.md
+++ b/tools/ai/intents/merge.trace.md
@@ -1,0 +1,42 @@
+# Intent: merge.trace
+
+You are TraceR, resolving a three-way merge conflict over the
+`<traces>` block of a payload element. Stage A already unioned rows
+by `(target, ref)`; you are only invoked when the union still
+contains divergent intent — e.g. one branch removed a row the other
+modified, or both branches added rows pointing at the same upstream
+with different `name` attributes.
+
+Your output MUST be a single JSON object matching the schema in the
+bundle. Return the **complete** trace list for the element — the
+TS-side applier replaces the entire `<traces>` block with your list.
+
+## Rules
+
+- Every row needs `target` ∈ {`SDD`, `PVD`, `HLR`, `LLR`} and a
+  non-empty `ref`. `name` is optional.
+- Do not invent refs. Pick from the candidate set in the bundle
+  (the union of refs from base, ours, and theirs).
+- When the same `(target, ref)` appears with conflicting `name`
+  attributes, prefer the longer/more descriptive one.
+- Never trace downstream (an HLR may not trace to LLRs/tests; an
+  LLR may not trace to tests).
+
+## Few-shot
+
+Bundle conflict candidates:
+- ours: `[{target: "SDD", ref: "tools/render_doc.py"}]`
+- theirs: `[{target: "SDD", ref: "tools/render_doc.py", name: "renderer"},
+            {target: "PVD", ref: "5"}]`
+
+Response:
+
+```json
+{
+  "traces": [
+    {"target": "SDD", "ref": "tools/render_doc.py", "name": "renderer"},
+    {"target": "PVD", "ref": "5"}
+  ],
+  "rationale": "theirs added a PVD trace; kept the more descriptive name."
+}
+```

--- a/tools/ai/pipeline.py
+++ b/tools/ai/pipeline.py
@@ -281,6 +281,21 @@ def run(
                 bundle_estimated_tokens=bundle.estimated_tokens,
             )
 
+        # Merge resolution: no JSON Patch, no apply_edit. The response
+        # is fed to ``project_merge.apply_resolution`` on the caller's
+        # side which substitutes it into the merged XML and re-lints
+        # the whole tree (Phase 5.5, HLR-034).
+        if intent.kind == "merge":
+            return AiResult(
+                kind="merge_resolved",
+                intent=intent_id,
+                target=target.to_dict(),
+                retries=attempt,
+                response=parsed,
+                bundle_estimated_tokens=bundle.estimated_tokens,
+            )
+
+
         # Authoring intent: translate → apply.
         try:
             patch = translate(
@@ -519,6 +534,24 @@ def evaluate(
                 response=parsed,
                 markdown=md,
                 advisory=list(questions),
+                bundle_estimated_tokens=bundle_tokens,
+            ),
+        )
+
+    if intent.kind == "merge":
+        # Phase 5.5: no patch, no apply_edit. The TS layer feeds the
+        # response into ``project_merge.apply_resolution`` and lints
+        # the post-substitution tree.
+        return StepResult(
+            kind="merge_resolved",
+            retries=retry_count,
+            bundle_estimated_tokens=bundle_tokens,
+            result=AiResult(
+                kind="merge_resolved",
+                intent=intent_id,
+                target=target.to_dict(),
+                retries=retry_count,
+                response=parsed,
                 bundle_estimated_tokens=bundle_tokens,
             ),
         )

--- a/tools/ai/registry.py
+++ b/tools/ai/registry.py
@@ -9,10 +9,16 @@ Each intent owns:
 
 * ``id``        — dotted intent name (e.g. ``"draft.hlr"``).
 * ``label``     — human-readable label for menus and chat.
-* ``kind``      — one of ``"authoring"`` | ``"pvd"`` | ``"advisory"``.
+* ``kind``      — one of ``"authoring"`` | ``"pvd"`` | ``"advisory"`` |
+                  ``"merge"``.
                   ``advisory`` intents (``review.item``) never produce
                   a JSON Patch; ``pvd`` intents (``draft.pvd``) target
-                  ``doc/PVD.md`` instead of ``Project.xml``.
+                  ``doc/PVD.md`` instead of ``Project.xml``; ``merge``
+                  intents (``merge.*``) target a residual conflict
+                  from ``project_merge.merge_three_way`` and return
+                  resolution payloads consumed by
+                  ``project_merge.apply_resolution`` (Phase 5.5,
+                  HLR-034).
 * ``targets``   — ``ui:treeNode`` payload kinds this intent applies to
                   (e.g. ``("Hlr",)``). Empty tuple means "global".
 * ``slash``     — slash command for the chat participant.
@@ -153,6 +159,47 @@ _REGISTRY: tuple[IntentSpec, ...] = (
         slash="gap-fill",
         schema="gap.fix.schema.json",
         prompt="gap.fix.md",
+    ),
+    # Phase 5.5 — AI-assisted merge conflict resolution (HLR-034).
+    # Each ``merge.*`` intent runs through the same validate→retry
+    # pipeline as the authoring intents but does not produce a JSON
+    # Patch: the resolution payload is substituted into the merged
+    # XML by ``project_merge.apply_resolution`` on the TS side.
+    IntentSpec(
+        id="merge.body",
+        label="Resolve merge body conflict with AI",
+        kind="merge",
+        targets=("Hlr", "Llr", "Test", "SddModule"),
+        slash="resolve-conflicts",
+        schema="merge.body.schema.json",
+        prompt="merge.body.md",
+    ),
+    IntentSpec(
+        id="merge.trace",
+        label="Resolve merge trace conflict with AI",
+        kind="merge",
+        targets=("Hlr", "Llr", "Test"),
+        slash="resolve-conflicts",
+        schema="merge.trace.schema.json",
+        prompt="merge.trace.md",
+    ),
+    IntentSpec(
+        id="merge.rename",
+        label="Resolve merge id collision with AI",
+        kind="merge",
+        targets=("Hlr", "Llr", "Test"),
+        slash="resolve-conflicts",
+        schema="merge.rename.schema.json",
+        prompt="merge.rename.md",
+    ),
+    IntentSpec(
+        id="merge.schema_bump",
+        label="Resolve schema_version conflict with AI",
+        kind="merge",
+        targets=("Project",),
+        slash="resolve-conflicts",
+        schema="merge.schema_bump.schema.json",
+        prompt="merge.schema_bump.md",
     ),
 )
 

--- a/tools/ai/schemas/merge.body.schema.json
+++ b/tools/ai/schemas/merge.body.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "merge.body response",
+  "type": "object",
+  "required": ["merged_xml"],
+  "properties": {
+    "merged_xml": {"type": "string", "minLength": 5},
+    "rationale": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/tools/ai/schemas/merge.rename.schema.json
+++ b/tools/ai/schemas/merge.rename.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "merge.rename response",
+  "type": "object",
+  "required": ["final_id"],
+  "properties": {
+    "final_id": {"type": "string", "minLength": 1},
+    "rationale": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/tools/ai/schemas/merge.schema_bump.schema.json
+++ b/tools/ai/schemas/merge.schema_bump.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "merge.schema_bump response",
+  "type": "object",
+  "required": ["schema_version"],
+  "properties": {
+    "schema_version": {"type": "string", "pattern": "^\\d+\\.\\d+$"},
+    "rationale": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/tools/ai/schemas/merge.trace.schema.json
+++ b/tools/ai/schemas/merge.trace.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "merge.trace response",
+  "type": "object",
+  "required": ["traces"],
+  "properties": {
+    "traces": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "required": ["target", "ref"],
+        "properties": {
+          "target": {"type": "string", "enum": ["SDD", "PVD", "HLR", "LLR"]},
+          "ref": {"type": "string", "minLength": 1},
+          "name": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "rationale": {"type": "string"}
+  },
+  "additionalProperties": false
+}

--- a/tools/project_io.py
+++ b/tools/project_io.py
@@ -127,6 +127,10 @@ from ai.pipeline import (
 )
 from ai.provenance import append_record as _ai_append_record
 from ai.registry import get_intent as _ai_get_intent
+from project_merge import (
+    merge_three_way as _merge_three_way,
+    apply_resolution as _merge_apply_resolution,
+)
 
 # JSON-RPC error codes (https://www.jsonrpc.org/specification#error_object).
 PARSE_ERROR = -32700
@@ -416,6 +420,47 @@ def _method_ai_request(params: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _method_merge_three_way(params: dict[str, Any]) -> dict[str, Any]:
+    """Phase 5.5 — Stage A deterministic structural merger (HLR-034).
+
+    Inputs are the three blob bodies from ``git show :1:`` / ``:2:`` /
+    ``:3:`` (XML strings). ``base`` may be null/empty to signal an
+    unavailable merge base; the merger refuses cleanly rather than
+    silently picking a side.
+    """
+    base = params.get("base")
+    ours = params.get("ours")
+    theirs = params.get("theirs")
+    if not isinstance(ours, str) or not ours.strip():
+        raise ValueError("merge_three_way requires non-empty string 'ours'")
+    if not isinstance(theirs, str) or not theirs.strip():
+        raise ValueError("merge_three_way requires non-empty string 'theirs'")
+    if base is not None and not isinstance(base, str):
+        raise ValueError("merge_three_way 'base' must be a string or null")
+    xsd_path = _as_path(params.get("xsd_path"), PROJECT_XSD)
+    result = _merge_three_way(base, ours, theirs, xsd_path=xsd_path)
+    return result.to_dict()
+
+
+def _method_apply_merge_resolution(params: dict[str, Any]) -> dict[str, Any]:
+    """Substitute a Stage-B resolution payload (manual or AI) into the
+    in-memory merged XML and return the new merged XML string. The
+    sidecar never writes the merged file: the merge editor is the only
+    commit surface (per SDP §5.9).
+    """
+    merged_xml = params.get("merged_xml")
+    if not isinstance(merged_xml, str) or not merged_xml.strip():
+        raise ValueError("apply_merge_resolution requires string 'merged_xml'")
+    conflict = params.get("conflict")
+    if not isinstance(conflict, dict):
+        raise ValueError("apply_merge_resolution requires 'conflict' object")
+    resolution = params.get("resolution")
+    if not isinstance(resolution, dict):
+        raise ValueError("apply_merge_resolution requires 'resolution' object")
+    new_xml = _merge_apply_resolution(merged_xml, conflict, resolution)
+    return {"merged_xml": new_xml}
+
+
 METHODS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "lint": _method_lint,
     "render": _method_render,
@@ -427,6 +472,8 @@ METHODS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "form_schema": _method_form_schema,
     "next_free_id": _method_next_free_id,
     "ai_request": _method_ai_request,
+    "merge_three_way": _method_merge_three_way,
+    "apply_merge_resolution": _method_apply_merge_resolution,
 }
 
 

--- a/tools/project_merge.py
+++ b/tools/project_merge.py
@@ -1,0 +1,939 @@
+#!/usr/bin/env python3
+"""Deterministic three-way structural merger for ``doc/Project.xml``
+(Phase 5.5 — Stage A in SDP §5.9.2 / SDD §9).
+
+The merger operates on lxml trees rather than the plain-dict
+projection because Stage A's contract is to *preserve* the on-disk
+formatting (comments, CDATA, attribute order, whitespace) the form
+webview write path also preserves (HLR-018). The dict projection
+from :func:`render_doc.parse_project_to_dict` is one-way and would
+silently rewrite developer-authored markup.
+
+Stage A handles every conflict it can without semantic reasoning:
+
+* New items added on either side that do not collide are unioned.
+* Items added on both sides with the same id but different content
+  trigger an id collision: ours keeps the id, the theirs-side copy
+  is reallocated to the next free id (existing ids never move,
+  HLR-005).
+* ``<traces>`` blocks are unioned by ``(target, ref)`` so two
+  branches that each add a different upstream link both survive.
+* Items removed on one side and unchanged on the other are removed.
+* Items removed on one side and modified on the other become a
+  residual ``modify_delete`` conflict for Stage B (the AI layer or
+  manual resolution in the merge editor).
+* Item bodies edited on both sides become a residual ``body``
+  conflict.
+* ``<metadata><counts>`` is recomputed from the merged tree so the
+  informational counts stay accurate.
+
+The function returns the merged XML bytes plus a list of structured
+``Conflict`` records. The TS layer drives Stage B by feeding each
+record through one of the four ``merge.*`` AI intents and
+substituting the resolved content back into the merged tree before
+opening VS Code's three-way merge editor (per HLR-034).
+
+Acceptance contract (SDP §5.9 Phase 5.5):
+
+* Two branches each adding a non-overlapping HLR to the same section
+  produce a clean merge with **no** AI involvement and pass lint.
+* Two branches editing the same `<hlr>` body produce a residual
+  `body` conflict (handled by Stage B).
+* The post-merge `Project.xml` lints with no *new* errors compared
+  to the union of the two parents' errors.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    from lxml import etree
+except ImportError as exc:  # pragma: no cover - lxml is required
+    raise RuntimeError(
+        "tools.project_merge requires lxml (pip install lxml)"
+    ) from exc
+
+from render_doc import PROJECT_XSD
+from lint_project import lint as _lint, DEFAULT_XSD as _LINT_DEFAULT_XSD
+
+
+# --------------------------------------------------------------------- #
+# Container registry                                                    #
+# --------------------------------------------------------------------- #
+#
+# A "container" is a parent element that holds an ordered list of
+# children identified by a key attribute. Adds/removes inside a
+# container are first-class merge operations; bodies of individual
+# items are merged as opaque text (with byte-equality comparison
+# falling back to a residual `body` conflict).
+#
+# This table is intentionally narrow: it covers every payload that
+# Phase 5 surfaces in the tree, the form panels, and the AI intent
+# matrix. Anything outside is treated as opaque content and a
+# divergence becomes a single residual `body` conflict on the
+# enclosing element.
+
+_CONTAINERS: tuple[tuple[str, str, str], ...] = (
+    # (parent xpath relative to root, child tag, key attribute)
+    ("hlrs/section",          "hlr",     "id"),
+    ("llrs/function",         "llr",     "id"),
+    ("tests/file",            "test",    "name"),
+    ("sdd/modules",           "module",  "path"),
+    ("stp",                   "fixture", "id"),
+)
+
+# Group containers by parent path so we can match the section/function/
+# file dimension first, then merge the inner item list.
+_GROUP_CONTAINERS: tuple[tuple[str, str, str], ...] = (
+    ("hlrs",     "section",  "number"),
+    ("llrs",     "function", "name"),
+    ("tests",    "file",     "path"),
+    ("sdd",      "modules",  None),     # singleton wrapper, no key
+)
+
+
+# --------------------------------------------------------------------- #
+# Result types                                                          #
+# --------------------------------------------------------------------- #
+
+@dataclass
+class Conflict:
+    """One residual merge conflict that Stage A could not resolve.
+
+    ``kind`` is one of:
+
+    * ``"body"``           — same item, body edited on both sides.
+    * ``"modify_delete"``  — one side removed an item the other modified.
+    * ``"id_collision"``   — both sides added items with the same id but
+                             different content; ours keeps the id, theirs
+                             is renumbered to ``rename_to``.
+    * ``"trace"``          — same item, traces edited on both sides
+                             with overlapping but non-identical
+                             changes (after the union pass).
+    * ``"schema_bump"``    — `schema_version` differs across all three
+                             inputs.
+    """
+    kind: str
+    container: str             # human-readable container path
+    key: str                   # the id/name/path of the conflicting item
+    type: str                  # complex-type hint for AI intent dispatch
+    base: str | None = None    # serialised content (xml string) on base
+    ours: str | None = None    # serialised content on ours
+    theirs: str | None = None  # serialised content on theirs
+    rename_to: str | None = None
+    note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class MergeResult:
+    merged_xml: str
+    residual_conflicts: list[Conflict] = field(default_factory=list)
+    lint: dict[str, Any] = field(default_factory=dict)
+    auto_resolved: int = 0
+    refused: bool = False
+    refusal: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "merged_xml": self.merged_xml,
+            "residual_conflicts": [c.to_dict() for c in self.residual_conflicts],
+            "lint": self.lint,
+            "auto_resolved": self.auto_resolved,
+            "refused": self.refused,
+            "refusal": self.refusal,
+        }
+
+
+class MergeError(RuntimeError):
+    pass
+
+
+# --------------------------------------------------------------------- #
+# Public entry point                                                    #
+# --------------------------------------------------------------------- #
+
+def merge_three_way(
+    base: str | bytes | Path | None,
+    ours: str | bytes | Path,
+    theirs: str | bytes | Path,
+    *,
+    xsd_path: str | Path = _LINT_DEFAULT_XSD,
+) -> MergeResult:
+    """Run Stage A: deterministic structural merge.
+
+    ``base`` is the common ancestor blob (`git show :1:Project.xml`),
+    ``ours`` is the index/HEAD side (`:2:`), and ``theirs`` is the
+    incoming branch (`:3:`). Each may be a Path, bytes, or string of
+    XML. ``base`` of None / empty signals an unavailable merge base
+    (rebase, octopus, cherry-pick without base) — Stage A refuses
+    rather than silently picking one side, per HLR-034.
+    """
+    if base is None:
+        return MergeResult(
+            merged_xml="",
+            refused=True,
+            refusal=(
+                "Stage A refuses: the Git merge base is unavailable "
+                "(rebase, octopus, or cherry-pick without a base). "
+                "Resolve manually in the merge editor."
+            ),
+        )
+    base_bytes = _read(base)
+    if not base_bytes.strip():
+        return MergeResult(
+            merged_xml="",
+            refused=True,
+            refusal=(
+                "Stage A refuses: the Git merge base is empty. "
+                "Resolve manually in the merge editor."
+            ),
+        )
+    ours_bytes = _read(ours)
+    theirs_bytes = _read(theirs)
+
+    parser = etree.XMLParser(
+        remove_blank_text=False,
+        remove_comments=False,
+        strip_cdata=False,
+        resolve_entities=False,
+    )
+    base_root = etree.fromstring(base_bytes, parser)
+    ours_root = etree.fromstring(ours_bytes, parser)
+    theirs_root = etree.fromstring(theirs_bytes, parser)
+
+    conflicts: list[Conflict] = []
+    auto = _Counter()
+
+    # 1. schema_version handling.
+    _merge_schema_version(base_root, ours_root, theirs_root, conflicts)
+
+    # 2. Walk the registered group containers (hlrs/section,
+    #    llrs/function, tests/file, sdd/modules) and recurse into
+    #    each item container.
+    for parent_xp, child_tag, key_attr in _GROUP_CONTAINERS:
+        _merge_group(
+            base_root, ours_root, theirs_root,
+            parent_xp=parent_xp,
+            group_tag=child_tag,
+            group_key=key_attr,
+            conflicts=conflicts,
+            auto=auto,
+        )
+
+    # 3. Recompute metadata/counts.
+    _recompute_counts(ours_root)
+
+    merged_bytes = etree.tostring(
+        ours_root,
+        xml_declaration=True,
+        encoding="UTF-8",
+    )
+    merged_xml = merged_bytes.decode("utf-8")
+
+    # 4. Lint the merged output (best-effort; lint failure does not
+    #    sink the merge — Stage A is responsible for structure, not
+    #    semantics).
+    lint_dict: dict[str, Any] = {}
+    try:
+        import tempfile, os
+        fd, tmp = tempfile.mkstemp(prefix=".project_merge_", suffix=".xml")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(merged_bytes)
+            findings = _lint(Path(tmp), Path(xsd_path))
+            lint_dict = findings.to_dict()
+            lint_dict["ok"] = not findings.errors
+        finally:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except Exception as exc:  # pragma: no cover - defensive
+        lint_dict = {
+            "errors": [f"lint failed: {exc}"],
+            "warnings": [],
+            "notes": [],
+            "items": [],
+            "ok": False,
+        }
+
+    return MergeResult(
+        merged_xml=merged_xml,
+        residual_conflicts=conflicts,
+        lint=lint_dict,
+        auto_resolved=auto.value,
+    )
+
+
+# --------------------------------------------------------------------- #
+# Internals                                                             #
+# --------------------------------------------------------------------- #
+
+class _Counter:
+    __slots__ = ("value",)
+    def __init__(self): self.value = 0
+    def inc(self, n: int = 1): self.value += n
+
+
+def _read(source: str | bytes | Path) -> bytes:
+    if isinstance(source, bytes):
+        return source.lstrip()
+    if isinstance(source, Path):
+        return source.read_bytes().lstrip()
+    if isinstance(source, str):
+        if not source.strip():
+            return b""
+        s = source.lstrip()
+        if s.startswith("<"):
+            return s.encode("utf-8")
+        return Path(source).read_bytes().lstrip()
+    raise TypeError(f"unsupported source type: {type(source).__name__}")
+
+
+def _xml_eq(a: "etree._Element | None", b: "etree._Element | None") -> bool:
+    """Byte-level equality comparison after canonicalisation."""
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    return etree.tostring(a) == etree.tostring(b)
+
+
+def _serialise(elem: "etree._Element | None") -> str | None:
+    if elem is None:
+        return None
+    return etree.tostring(elem, pretty_print=False).decode("utf-8")
+
+
+def _merge_schema_version(
+    base: "etree._Element",
+    ours: "etree._Element",
+    theirs: "etree._Element",
+    conflicts: list[Conflict],
+) -> None:
+    bv = base.get("schema_version")
+    ov = ours.get("schema_version")
+    tv = theirs.get("schema_version")
+    if ov == tv:
+        return
+    if ov == bv:
+        ours.set("schema_version", tv or "")
+        return
+    if tv == bv:
+        return  # ours already wins
+    # Three-way divergence — surface as a residual conflict.
+    conflicts.append(Conflict(
+        kind="schema_bump",
+        container="/project",
+        key="schema_version",
+        type="Project",
+        base=bv,
+        ours=ov,
+        theirs=tv,
+        note="schema_version differs on all three sides",
+    ))
+
+
+def _merge_group(
+    base_root: "etree._Element",
+    ours_root: "etree._Element",
+    theirs_root: "etree._Element",
+    *,
+    parent_xp: str,
+    group_tag: str,
+    group_key: str | None,
+    conflicts: list[Conflict],
+    auto: _Counter,
+) -> None:
+    """Merge the children of a wrapper element keyed by ``group_key``.
+
+    For ``hlrs/section`` this dispatches into per-section item merges
+    keyed on ``hlr/@id``. For singletons (``sdd/modules``) we collapse
+    to a single virtual group.
+    """
+    base_parent = base_root.find(parent_xp)
+    ours_parent = ours_root.find(parent_xp)
+    theirs_parent = theirs_root.find(parent_xp)
+    if ours_parent is None and theirs_parent is None:
+        return
+    if ours_parent is None:
+        # Branch added the entire wrapper. Append it under root.
+        ours_root.append(deepcopy(theirs_parent))
+        auto.inc()
+        return
+    if theirs_parent is None:
+        return
+
+    if group_key is None:
+        # Singleton wrapper: merge a single virtual group.
+        _merge_item_container(
+            base_parent, ours_parent, theirs_parent,
+            container_path=f"/{parent_xp}",
+            conflicts=conflicts,
+            auto=auto,
+        )
+        return
+
+    # Index groups by key.
+    base_groups = _index(base_parent, group_tag, group_key)
+    ours_groups = _index(ours_parent, group_tag, group_key)
+    theirs_groups = _index(theirs_parent, group_tag, group_key)
+
+    # Add any groups present in theirs but not in ours.
+    for k, t_elem in theirs_groups.items():
+        if k in ours_groups:
+            continue
+        if k in base_groups and _xml_eq(t_elem, base_groups[k]):
+            # Removed on ours, unchanged on theirs → respect deletion.
+            continue
+        ours_parent.append(deepcopy(t_elem))
+        ours_groups[k] = ours_parent.find(f"./{group_tag}[@{group_key}={_q(k)}]")
+        auto.inc()
+
+    # Recurse into each shared group.
+    for k, ours_group in list(ours_groups.items()):
+        base_group = base_groups.get(k)
+        theirs_group = theirs_groups.get(k)
+        if theirs_group is None:
+            if base_group is not None and _xml_eq(ours_group, base_group):
+                # Removed on theirs, unchanged on ours → drop.
+                ours_parent.remove(ours_group)
+                auto.inc()
+            # else ours-side modification preserved (modify wins over delete
+            # would be the wrong default; we keep ours and surface the
+            # divergence as a conflict only if theirs side actually deleted
+            # something that base contained).
+            elif base_group is not None and not _xml_eq(ours_group, base_group):
+                conflicts.append(Conflict(
+                    kind="modify_delete",
+                    container=f"/{parent_xp}/{group_tag}[@{group_key}={_q(k)}]",
+                    key=str(k),
+                    type=group_tag.capitalize(),
+                    base=_serialise(base_group),
+                    ours=_serialise(ours_group),
+                    theirs=None,
+                    note="theirs deleted, ours modified",
+                ))
+            continue
+        _merge_item_container(
+            base_group, ours_group, theirs_group,
+            container_path=f"/{parent_xp}/{group_tag}[@{group_key}={_q(k)}]",
+            conflicts=conflicts,
+            auto=auto,
+        )
+
+
+def _merge_item_container(
+    base_parent: "etree._Element | None",
+    ours_parent: "etree._Element",
+    theirs_parent: "etree._Element",
+    *,
+    container_path: str,
+    conflicts: list[Conflict],
+    auto: _Counter,
+) -> None:
+    """Merge the items under a shared parent.
+
+    Looks up which item tag/key applies to this container path from
+    :data:`_CONTAINERS`. If no entry matches, falls back to a body
+    merge of the whole element.
+    """
+    item_tag, key_attr = _container_for(container_path)
+    if item_tag is None:
+        _merge_opaque(
+            base_parent, ours_parent, theirs_parent,
+            container_path=container_path,
+            conflicts=conflicts,
+            auto=auto,
+        )
+        return
+
+    base_items = _index(base_parent, item_tag, key_attr) if base_parent is not None else {}
+    ours_items = _index(ours_parent, item_tag, key_attr)
+    theirs_items = _index(theirs_parent, item_tag, key_attr)
+
+    # Allocate next free ids if id collisions on a key like "id" require
+    # renumbering the theirs side. We use the union of keys across all
+    # three trees as the "in use" set.
+    in_use: set[str] = set()
+    for d in (base_items, ours_items, theirs_items):
+        in_use.update(d.keys())
+
+    # Pass 1: items added on theirs but not on ours.
+    for k, t_item in list(theirs_items.items()):
+        if k in ours_items:
+            continue
+        if k in base_items and _xml_eq(t_item, base_items[k]):
+            # Removed on ours unchanged on theirs → drop.
+            continue
+        # New on theirs.
+        ours_parent.append(deepcopy(t_item))
+        ours_items[k] = ours_parent.find(f"./{item_tag}[@{key_attr}={_q(k)}]")
+        auto.inc()
+
+    # Pass 2: items in both ours and theirs — body merge.
+    for k, ours_item in list(ours_items.items()):
+        base_item = base_items.get(k)
+        theirs_item = theirs_items.get(k)
+        if theirs_item is None:
+            # Either removed on theirs or never added there.
+            if base_item is not None and _xml_eq(ours_item, base_item):
+                ours_parent.remove(ours_item)
+                auto.inc()
+            elif base_item is not None and not _xml_eq(ours_item, base_item):
+                conflicts.append(Conflict(
+                    kind="modify_delete",
+                    container=container_path,
+                    key=str(k),
+                    type=item_tag.capitalize(),
+                    base=_serialise(base_item),
+                    ours=_serialise(ours_item),
+                    theirs=None,
+                    note="theirs deleted, ours modified",
+                ))
+            continue
+
+        if _xml_eq(ours_item, theirs_item):
+            continue  # identical edits or no edits
+
+        # Branched modify/add cases.
+        if base_item is None:
+            # Both added, same key, different content → id collision.
+            new_key = _allocate_free_id(k, in_use)
+            in_use.add(new_key)
+            renamed = deepcopy(theirs_item)
+            renamed.set(key_attr, new_key)
+            ours_parent.append(renamed)
+            conflicts.append(Conflict(
+                kind="id_collision",
+                container=container_path,
+                key=str(k),
+                type=item_tag.capitalize(),
+                base=None,
+                ours=_serialise(ours_item),
+                theirs=_serialise(theirs_item),
+                rename_to=new_key,
+                note=f"both branches added {k!r}; theirs renamed to {new_key!r}",
+            ))
+            auto.inc()
+            continue
+
+        if _xml_eq(ours_item, base_item):
+            # Only theirs changed → take theirs.
+            _replace_in_place(ours_parent, ours_item, deepcopy(theirs_item))
+            ours_items[k] = ours_parent.find(f"./{item_tag}[@{key_attr}={_q(k)}]")
+            auto.inc()
+            continue
+        if _xml_eq(theirs_item, base_item):
+            # Only ours changed → keep ours.
+            continue
+
+        # Both sides changed differently. Try to resolve at finer
+        # granularity: traces unioned by (target,ref); body residual.
+        if _try_field_level_merge(
+            base_item, ours_item, theirs_item,
+            container_path=container_path,
+            key=str(k),
+            type_name=item_tag.capitalize(),
+            conflicts=conflicts,
+            auto=auto,
+        ):
+            continue
+
+        conflicts.append(Conflict(
+            kind="body",
+            container=container_path,
+            key=str(k),
+            type=item_tag.capitalize(),
+            base=_serialise(base_item),
+            ours=_serialise(ours_item),
+            theirs=_serialise(theirs_item),
+            note="both sides edited the body",
+        ))
+
+
+def _merge_opaque(
+    base: "etree._Element | None",
+    ours: "etree._Element",
+    theirs: "etree._Element",
+    *,
+    container_path: str,
+    conflicts: list[Conflict],
+    auto: _Counter,
+) -> None:
+    if _xml_eq(ours, theirs):
+        return
+    if base is not None and _xml_eq(ours, base):
+        # Replace ours' children with theirs' children in place.
+        for c in list(ours):
+            ours.remove(c)
+        for c in list(theirs):
+            ours.append(deepcopy(c))
+        ours.text = theirs.text
+        auto.inc()
+        return
+    if base is not None and _xml_eq(theirs, base):
+        return
+    conflicts.append(Conflict(
+        kind="body",
+        container=container_path,
+        key="",
+        type=ours.tag.capitalize(),
+        base=_serialise(base),
+        ours=_serialise(ours),
+        theirs=_serialise(theirs),
+        note="both sides edited an opaque container",
+    ))
+
+
+def _try_field_level_merge(
+    base_item: "etree._Element",
+    ours_item: "etree._Element",
+    theirs_item: "etree._Element",
+    *,
+    container_path: str,
+    key: str,
+    type_name: str,
+    conflicts: list[Conflict],
+    auto: _Counter,
+) -> bool:
+    """Attempt to resolve a both-modified item by merging individual
+    children. If the only divergence is in ``<traces>`` we can union by
+    (target, ref); other divergent children fall through to a body
+    conflict.
+
+    Returns True iff every divergent child was resolvable without a
+    residual conflict.
+    """
+    # Compare each child by tag.
+    base_children = list(base_item)
+    ours_children = list(ours_item)
+    theirs_children = list(theirs_item)
+
+    # Build per-tag groups (most payloads have unique child tags).
+    def _by_tag(children: list) -> dict[str, list]:
+        out: dict[str, list] = {}
+        for c in children:
+            out.setdefault(c.tag, []).append(c)
+        return out
+
+    base_t = _by_tag(base_children)
+    ours_t = _by_tag(ours_children)
+    theirs_t = _by_tag(theirs_children)
+
+    all_tags = set(base_t) | set(ours_t) | set(theirs_t)
+    body_conflict_tags: list[str] = []
+    trace_conflict = False
+
+    for tag in all_tags:
+        b = base_t.get(tag, [])
+        o = ours_t.get(tag, [])
+        t = theirs_t.get(tag, [])
+        if [etree.tostring(x) for x in o] == [etree.tostring(x) for x in t]:
+            continue
+        if [etree.tostring(x) for x in o] == [etree.tostring(x) for x in b]:
+            # Replace ours' children of this tag with theirs.
+            for x in o:
+                ours_item.remove(x)
+            for x in t:
+                ours_item.append(deepcopy(x))
+            auto.inc()
+            continue
+        if [etree.tostring(x) for x in t] == [etree.tostring(x) for x in b]:
+            continue  # ours wins
+        if tag == "traces" and o and t:
+            # Union by (target, ref).
+            unioned = _union_traces(b[0] if b else None, o[0], t[0])
+            ours_item.remove(o[0])
+            ours_item.append(unioned)
+            auto.inc()
+            continue
+        body_conflict_tags.append(tag)
+
+    # Attribute divergence (e.g. @name on hlr): treat as body conflict.
+    base_attrs = dict(base_item.attrib)
+    ours_attrs = dict(ours_item.attrib)
+    theirs_attrs = dict(theirs_item.attrib)
+    for ak in set(base_attrs) | set(ours_attrs) | set(theirs_attrs):
+        ov = ours_attrs.get(ak)
+        tv = theirs_attrs.get(ak)
+        bv = base_attrs.get(ak)
+        if ov == tv:
+            continue
+        if ov == bv:
+            if tv is None:
+                ours_item.attrib.pop(ak, None)
+            else:
+                ours_item.set(ak, tv)
+            auto.inc()
+            continue
+        if tv == bv:
+            continue
+        body_conflict_tags.append(f"@{ak}")
+
+    if not body_conflict_tags:
+        return True
+
+    # Caller is responsible for appending the body conflict so we
+    # don't double-count when only one container path is in play.
+    return False
+
+
+def _union_traces(
+    base: "etree._Element | None",
+    ours: "etree._Element",
+    theirs: "etree._Element",
+) -> "etree._Element":
+    """Return a new ``<traces>`` element containing the union of
+    ``<trace>`` rows from ours and theirs (and any base rows still
+    present on either side). Rows are keyed by ``(target, ref)``.
+    """
+    seen: dict[tuple[str, str], "etree._Element"] = {}
+    base_keys = set()
+    if base is not None:
+        for t in base:
+            if t.tag == "trace":
+                base_keys.add((t.get("target", ""), t.get("ref", "")))
+    for source in (ours, theirs):
+        for trace in source:
+            if trace.tag != "trace":
+                continue
+            k = (trace.get("target", ""), trace.get("ref", ""))
+            if k in seen:
+                continue
+            seen[k] = deepcopy(trace)
+    # Deletions: a row that was in base but is missing on BOTH ours and
+    # theirs is a deliberate deletion. We keep rows that survived on at
+    # least one side, which is the union semantics requested.
+    merged = etree.Element("traces")
+    for k, trace in seen.items():
+        merged.append(trace)
+    # Preserve original tail of ours' first child for whitespace continuity.
+    return merged
+
+
+# --------------------------------------------------------------------- #
+# Helpers                                                               #
+# --------------------------------------------------------------------- #
+
+def _index(parent: "etree._Element | None", tag: str, key_attr: str) -> dict[str, "etree._Element"]:
+    out: dict[str, "etree._Element"] = {}
+    if parent is None:
+        return out
+    for child in parent:
+        if child.tag != tag:
+            continue
+        k = child.get(key_attr)
+        if k is None:
+            continue
+        out[k] = child
+    return out
+
+
+def _q(value: str) -> str:
+    """Quote an attribute value for an xpath predicate."""
+    if "'" in value:
+        return f'"{value}"'
+    return f"'{value}'"
+
+
+def _container_for(container_path: str) -> tuple[str | None, str | None]:
+    """Return (item_tag, key_attr) for a given container path, or
+    (None, None) if the path is not a registered list container."""
+    # container_path looks like '/hlrs/section[@number=...]' or '/sdd/modules'
+    for parent_xp, child_tag, key_attr in _CONTAINERS:
+        # Match if container_path ends with the parent_xp head or a
+        # group-keyed instance of it.
+        head = parent_xp.split("/")[0]      # e.g. "hlrs"
+        tail = parent_xp.split("/")[-1]     # e.g. "section"
+        if (
+            container_path == f"/{parent_xp}"
+            or container_path.startswith(f"/{head}/{tail}[")
+            or container_path.startswith(f"/{head}/{tail}/")
+            or container_path == f"/{head}"  # singleton wrappers
+        ):
+            return child_tag, key_attr
+    return None, None
+
+
+def _allocate_free_id(existing: str, in_use: set[str]) -> str:
+    """Allocate the next free id of the same shape as ``existing``.
+
+    Supports two shapes used by the Project.xml id contract:
+
+    * ``HLR-NNN``     (HLR-005)
+    * ``LLR-XXX-NN``  (LLR-005)
+
+    For other patterns we append ``-1``, ``-2`` … until a free name
+    appears.
+    """
+    import re
+    m = re.match(r"^(HLR-)(\d+)$", existing)
+    if m:
+        prefix = m.group(1)
+        n = int(m.group(2))
+        while True:
+            n += 1
+            cand = f"{prefix}{n:03d}"
+            if cand not in in_use:
+                return cand
+    m = re.match(r"^(LLR-[^-]+-)(\d+)$", existing)
+    if m:
+        prefix = m.group(1)
+        n = int(m.group(2))
+        while True:
+            n += 1
+            cand = f"{prefix}{n:02d}"
+            if cand not in in_use:
+                return cand
+    n = 1
+    while f"{existing}-{n}" in in_use:
+        n += 1
+    return f"{existing}-{n}"
+
+
+def _replace_in_place(
+    parent: "etree._Element",
+    old: "etree._Element",
+    new: "etree._Element",
+) -> None:
+    idx = list(parent).index(old)
+    parent.remove(old)
+    parent.insert(idx, new)
+
+
+def _recompute_counts(root: "etree._Element") -> None:
+    counts = root.find("metadata/counts")
+    if counts is None:
+        return
+    mapping = {
+        "hlrs":     len(root.findall("hlrs/section/hlr")),
+        "llrs":     len(root.findall("llrs/function/llr")),
+        "tests":    len(root.findall("tests/file/test")),
+        "modules":  len(root.findall("sdd/modules/module")),
+        "fixtures": len(root.findall("stp/fixture")),
+    }
+    for child in counts:
+        tag = child.tag
+        if tag in mapping:
+            child.text = str(mapping[tag])
+
+
+# --------------------------------------------------------------------- #
+# Conflict resolution helpers (Stage B feed)                            #
+# --------------------------------------------------------------------- #
+
+def apply_resolution(
+    merged_xml: str | bytes,
+    conflict: Conflict | dict[str, Any],
+    resolution: dict[str, Any],
+) -> str:
+    """Substitute a Stage-B (AI or manual) resolution into the merged
+    XML and return the new merged XML string.
+
+    ``resolution`` shapes (per intent):
+
+    * ``merge.body``      → ``{"merged_xml": "<hlr ...>...</hlr>"}``
+                            (single complete payload element)
+    * ``merge.trace``     → ``{"traces": [{"target", "ref", "name?"}, ...]}``
+    * ``merge.rename``    → ``{"final_id": "HLR-NNN"}`` (rename the
+                            ``rename_to`` placeholder back to a chosen id)
+    * ``merge.schema_bump`` → ``{"schema_version": "1.6"}``
+    """
+    if isinstance(conflict, dict):
+        kind = conflict.get("kind")
+        container = conflict.get("container", "")
+        key = conflict.get("key", "")
+        rename_to = conflict.get("rename_to")
+    else:
+        kind = conflict.kind
+        container = conflict.container
+        key = conflict.key
+        rename_to = conflict.rename_to
+
+    parser = etree.XMLParser(
+        remove_blank_text=False,
+        remove_comments=False,
+        strip_cdata=False,
+        resolve_entities=False,
+    )
+    root = etree.fromstring(
+        merged_xml.encode("utf-8") if isinstance(merged_xml, str) else merged_xml,
+        parser,
+    )
+
+    if kind == "schema_bump":
+        new_v = (resolution.get("schema_version") or "").strip()
+        if new_v:
+            root.set("schema_version", new_v)
+    elif kind == "body":
+        target = root.find(container.lstrip("/"))
+        if target is None:
+            raise MergeError(f"apply_resolution: cannot locate {container!r}")
+        new_body = resolution.get("merged_xml") or ""
+        new_elem = etree.fromstring(new_body.encode("utf-8"), parser)
+        parent = target.getparent()
+        idx = list(parent).index(target)
+        parent.remove(target)
+        parent.insert(idx, new_elem)
+    elif kind == "trace":
+        target = root.find(container.lstrip("/"))
+        if target is None:
+            raise MergeError(f"apply_resolution: cannot locate {container!r}")
+        new_traces = etree.SubElement(target, "_tmp_traces")
+        for t in resolution.get("traces") or []:
+            tr = etree.SubElement(new_traces, "trace")
+            tr.set("target", str(t.get("target", "")))
+            tr.set("ref", str(t.get("ref", "")))
+            if t.get("name"):
+                tr.set("name", str(t["name"]))
+        existing = target.find("traces")
+        if existing is not None:
+            target.remove(existing)
+        new_traces.tag = "traces"
+    elif kind == "rename":
+        if rename_to:
+            for elem in root.iter():
+                for ak, av in list(elem.attrib.items()):
+                    if av == rename_to:
+                        final = (resolution.get("final_id") or "").strip()
+                        if final:
+                            elem.set(ak, final)
+    elif kind == "id_collision":
+        # The renamed theirs-side item already lives in the tree under
+        # rename_to; the resolution lets the user pick a final id.
+        final = (resolution.get("final_id") or "").strip()
+        if final and rename_to:
+            for elem in root.iter():
+                if elem.get("id") == rename_to or elem.get("name") == rename_to:
+                    for ak in ("id", "name"):
+                        if elem.get(ak) == rename_to:
+                            elem.set(ak, final)
+    elif kind == "modify_delete":
+        # Default policy: keep ours (modify wins). The TS layer can
+        # also pass a "delete": True flag to remove the item.
+        if resolution.get("delete"):
+            target = root.find(container.lstrip("/"))
+            if target is not None:
+                target.getparent().remove(target)
+    else:
+        raise MergeError(f"apply_resolution: unsupported conflict kind {kind!r}")
+
+    return etree.tostring(
+        root, xml_declaration=True, encoding="UTF-8",
+    ).decode("utf-8")
+
+
+__all__ = [
+    "Conflict",
+    "MergeResult",
+    "MergeError",
+    "merge_three_way",
+    "apply_resolution",
+]

--- a/tools/vscode-project-xml/package.json
+++ b/tools/vscode-project-xml/package.json
@@ -127,6 +127,10 @@
       {
         "command": "projectXml.ai.fix.suggestTrace",
         "title": "Project Spec: Suggest correct ref with AI"
+      },
+      {
+        "command": "projectXml.resolveMergeConflicts",
+        "title": "Project Spec: Resolve Project.xml merge conflicts…"
       }
     ],
     "walkthroughs": [
@@ -309,6 +313,16 @@
           "type": "boolean",
           "default": true,
           "description": "Append every accepted/rejected AI step to <workspace>/.edit_doc/ai_history.jsonl for audit (HLR-049). Set to false to disable provenance logging."
+        },
+        "projectXml.merge.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Stage A deterministic three-way structural merge for doc/Project.xml when Git reports a conflict on that file. The merger preserves comments/CDATA/attribute order, unions <trace> rows, auto-resolves disjoint adds, and reallocates colliding ids; residual conflicts are surfaced for Stage B (HLR-063)."
+        },
+        "projectXml.merge.aiResidualResolution": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use the AI layer (merge.* intents) to suggest resolutions for residual conflicts surfaced by the Stage A merger. Suggestions are badged '✨ AI suggestion' in the merge editor; the user always picks the final region (HLR-068). Forced false when projectXml.ai.enabled is false (HLR-034)."
         }
       }
     },
@@ -320,15 +334,16 @@
         "description": "TraceR's schema-aware AI ghostwriter for Project.xml and PVD.md.",
         "isSticky": true,
         "commands": [
-          { "name": "draft-hlr",       "description": "Draft an HLR with AI" },
-          { "name": "draft-llr",       "description": "Draft an LLR with AI" },
-          { "name": "draft-test",      "description": "Draft a test with AI" },
-          { "name": "draft-module",    "description": "Draft an SDD module with AI" },
-          { "name": "draft-pvd",       "description": "Draft a PVD section with AI" },
-          { "name": "expand",          "description": "Expand an HLR into LLRs (or an LLR into tests)" },
-          { "name": "review",          "description": "Review an item for advisory findings" },
-          { "name": "suggest-traces",  "description": "Suggest correct trace targets" },
-          { "name": "gap-fill",        "description": "Propose fixes for outstanding coverage gaps" }
+          { "name": "draft-hlr",         "description": "Draft an HLR with AI" },
+          { "name": "draft-llr",         "description": "Draft an LLR with AI" },
+          { "name": "draft-test",        "description": "Draft a test with AI" },
+          { "name": "draft-module",      "description": "Draft an SDD module with AI" },
+          { "name": "draft-pvd",         "description": "Draft a PVD section with AI" },
+          { "name": "expand",            "description": "Expand an HLR into LLRs (or an LLR into tests)" },
+          { "name": "review",            "description": "Review an item for advisory findings" },
+          { "name": "suggest-traces",    "description": "Suggest correct trace targets" },
+          { "name": "gap-fill",          "description": "Propose fixes for outstanding coverage gaps" },
+          { "name": "resolve-conflicts", "description": "Resolve a Git merge conflict on doc/Project.xml" }
         ]
       }
     ]

--- a/tools/vscode-project-xml/src/ai/intents.ts
+++ b/tools/vscode-project-xml/src/ai/intents.ts
@@ -16,7 +16,7 @@
 // `test/test_ai_registry.py` and the unit test for this file exercise
 // the matching.
 
-export type IntentKind = 'authoring' | 'pvd' | 'advisory';
+export type IntentKind = 'authoring' | 'pvd' | 'advisory' | 'merge';
 
 export interface IntentSpec {
     id: string;
@@ -39,6 +39,13 @@ export const INTENTS: readonly IntentSpec[] = [
     { id: 'review.item',        label: 'Review with AI',               kind: 'advisory',  targets: ['Hlr', 'Llr', 'Test', 'SddModule'], slash: 'review' },
     { id: 'suggest.traces',     label: 'Suggest traces with AI',       kind: 'authoring', targets: ['Hlr', 'Llr', 'Test'],               slash: 'suggest-traces' },
     { id: 'gap.fix',            label: 'Fix coverage gap with AI',     kind: 'authoring', targets: ['Hlr', 'Llr'],                       slash: 'gap-fill' },
+    // Phase 5.5 (HLR-063..069): merge conflict resolution. All four
+    // share the `/resolve-conflicts` slash; the resolver picks the
+    // right intent per residual conflict kind.
+    { id: 'merge.body',         label: 'AI suggestion for body conflict',         kind: 'merge', targets: ['Hlr', 'Llr', 'Test', 'SddModule'], slash: 'resolve-conflicts' },
+    { id: 'merge.trace',        label: 'AI suggestion for trace conflict',        kind: 'merge', targets: ['Traces'],                          slash: 'resolve-conflicts' },
+    { id: 'merge.rename',       label: 'AI suggestion for id collision',          kind: 'merge', targets: ['Hlr', 'Llr'],                      slash: 'resolve-conflicts' },
+    { id: 'merge.schema_bump',  label: 'AI suggestion for schema_version bump',   kind: 'merge', targets: ['Project'],                         slash: 'resolve-conflicts' },
 ];
 
 const BY_ID = new Map<string, IntentSpec>(INTENTS.map((i) => [i.id, i]));

--- a/tools/vscode-project-xml/src/ai/participant.ts
+++ b/tools/vscode-project-xml/src/ai/participant.ts
@@ -91,6 +91,17 @@ async function handleTurn(
         stream.markdown(helpMessage());
         return {};
     }
+    // Phase 5.5: `/resolve-conflicts` is a headless command that
+    // delegates to MergeConflictResolver via its registered command.
+    if (slash === 'resolve-conflicts') {
+        stream.progress('Resolving Project.xml merge conflicts…');
+        await vscode.commands.executeCommand('projectXml.resolveMergeConflicts');
+        stream.markdown(
+            'Triggered **Project Spec: Resolve Project.xml merge conflicts…**. ' +
+                'See the Project Spec output channel for per-region results.',
+        );
+        return {};
+    }
     const userPrompt = (request.prompt || '').trim();
     const explicitTarget = parseTargetFlag(userPrompt);
     const intent = intentForSlash(slash, explicitTarget?.type);
@@ -202,6 +213,13 @@ async function renderOutcome(
             stream.markdown(
                 'No language model is available. Install a chat model ' +
                     'extension (e.g. GitHub Copilot Chat) and try again.',
+            );
+            return {};
+        }
+        case 'merge_resolved': {
+            stream.markdown(
+                `**Merge suggestion** \`${intent.id}\` produced a candidate; ` +
+                    'the resolver applies it via the merge editor.',
             );
             return {};
         }

--- a/tools/vscode-project-xml/src/commands/resolveMerge.ts
+++ b/tools/vscode-project-xml/src/commands/resolveMerge.ts
@@ -1,0 +1,20 @@
+// Phase 5.5 — `projectXml.resolveMergeConflicts` command (HLR-063, HLR-067).
+//
+// Thin wrapper around `MergeConflictResolver.resolve()`. Lives in its
+// own module so extension.ts only needs to import a single function
+// per command (matching the convention used by other commands/).
+
+import * as vscode from 'vscode';
+import { MergeConflictResolver, MergeResolverDeps } from '../merge/MergeConflictResolver';
+
+export const RESOLVE_MERGE_COMMAND = 'projectXml.resolveMergeConflicts';
+
+export function registerResolveMergeCommand(
+    deps: MergeResolverDeps,
+): vscode.Disposable {
+    const resolver = new MergeConflictResolver(deps);
+    return vscode.commands.registerCommand(
+        RESOLVE_MERGE_COMMAND,
+        () => resolver.resolve(),
+    );
+}

--- a/tools/vscode-project-xml/src/extension.ts
+++ b/tools/vscode-project-xml/src/extension.ts
@@ -54,6 +54,7 @@ import {
     AiQuickFixProvider,
     runAiSuggestTrace,
 } from './ai/quickFix';
+import { registerResolveMergeCommand } from './commands/resolveMerge';
 
 export function activate(context: vscode.ExtensionContext): void {
     const output = vscode.window.createOutputChannel('Project Spec');
@@ -187,6 +188,13 @@ export function activate(context: vscode.ExtensionContext): void {
                 args,
             ),
         ),
+    );
+
+    // Phase 5.5: AI-assisted merge conflict resolution.
+    context.subscriptions.push(
+        registerResolveMergeCommand({
+            sidecar, capabilities, aiClient, output,
+        }),
     );
 
     // Phase 3 + Phase 4 form panel commands. Each registered command

--- a/tools/vscode-project-xml/src/merge/MergeConflictResolver.ts
+++ b/tools/vscode-project-xml/src/merge/MergeConflictResolver.ts
@@ -1,0 +1,392 @@
+// Phase 5.5 — AI-assisted merge conflict resolution (HLR-063..069).
+//
+// Detects a Git MERGE state on doc/Project.xml, runs the deterministic
+// Stage A merger (`tools/project_merge.py` via the sidecar's
+// `merge_three_way` JSON-RPC method), and then walks any residual
+// conflicts. Each residual is shown to the user with — when AI is
+// available and `projectXml.merge.aiResidualResolution` is on — a
+// "✨ AI suggestion" generated via the `merge.*` intents.
+//
+// The merge editor is the only commit surface: this resolver never
+// writes to doc/Project.xml without an explicit accept gesture from
+// the user. When the merge base is unavailable the Stage A merger
+// refuses cleanly (HLR-034) and the resolver tells the user to fall
+// back to manual conflict-marker resolution.
+
+import * as crypto from 'crypto';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { AiClient } from '../ai/AiClient';
+import { AiCapabilityProvider } from '../ai/capabilities';
+import {
+    AiTarget,
+    MergeConflict,
+    MergeConflictKind,
+    ProjectIoClient,
+} from '../sidecar';
+import {
+    getConfig,
+    getProjectFolder,
+    getProjectXmlPath,
+    getXsdPath,
+} from '../util/paths';
+
+interface ResidualOutcome {
+    conflict: MergeConflict;
+    /** AI-suggested resolution payload (intent-specific shape) when one
+     *  was produced; null when the user declined or AI was unavailable. */
+    aiPayload: Record<string, unknown> | null;
+    /** Free-form rationale string the model returned (when present). */
+    rationale: string | null;
+    /** Intent id used to produce the suggestion (`merge.body`, etc.). */
+    intent: string | null;
+    /** Final user choice: `'ours' | 'theirs' | 'ai' | 'skip'`. */
+    decision: 'ours' | 'theirs' | 'ai' | 'skip';
+}
+
+export interface MergeResolverDeps {
+    sidecar: ProjectIoClient;
+    capabilities: AiCapabilityProvider;
+    aiClient: AiClient;
+    output: vscode.OutputChannel;
+}
+
+/** Map a residual conflict kind to the AI intent that resolves it. */
+function intentForConflict(kind: MergeConflictKind): string {
+    switch (kind) {
+        case 'body':
+        case 'modify_delete':
+            return 'merge.body';
+        case 'trace':
+            return 'merge.trace';
+        case 'id_collision':
+            return 'merge.rename';
+        case 'schema_bump':
+            return 'merge.schema_bump';
+    }
+}
+
+/** Map a residual conflict to the AI target descriptor. */
+function targetForConflict(conflict: MergeConflict): AiTarget {
+    return {
+        type: conflict.type || 'Hlr',
+        id: conflict.key,
+        extra: { container: conflict.container },
+    };
+}
+
+/** True when Git reports this file as conflicted (UU / AA / DU / UD / etc.). */
+async function isConflicted(uri: vscode.Uri): Promise<boolean> {
+    try {
+        const ext = vscode.extensions.getExtension('vscode.git');
+        if (!ext) {
+            return false;
+        }
+        const api = (ext.isActive ? ext.exports : await ext.activate())
+            .getAPI(1);
+        for (const repo of api.repositories) {
+            const merge = repo.state.mergeChanges?.find(
+                (c: { uri: vscode.Uri }) => c.uri.fsPath === uri.fsPath,
+            );
+            if (merge) {
+                return true;
+            }
+        }
+    } catch {
+        // git extension absent → fall through to false
+    }
+    return false;
+}
+
+/** Run `git show :N:<relPath>` for a stage; returns null when missing. */
+async function gitShowStage(
+    cwd: string,
+    relPath: string,
+    stage: 1 | 2 | 3,
+): Promise<string | null> {
+    const { spawn } = await import('child_process');
+    return new Promise((resolve) => {
+        const proc = spawn('git', ['show', `:${stage}:${relPath}`], {
+            cwd, stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const chunks: Buffer[] = [];
+        proc.stdout.on('data', (c) => chunks.push(c));
+        proc.on('error', () => resolve(null));
+        proc.on('exit', (code) => {
+            if (code !== 0) {
+                resolve(null);
+                return;
+            }
+            resolve(Buffer.concat(chunks).toString('utf8'));
+        });
+    });
+}
+
+function sha1(input: string | null): string {
+    if (input == null) {
+        return 'null';
+    }
+    return crypto.createHash('sha1').update(input).digest('hex').slice(0, 12);
+}
+
+async function appendProvenance(
+    folderFs: string,
+    record: Record<string, unknown>,
+): Promise<void> {
+    const dir = path.join(folderFs, '.edit_doc');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.appendFile(
+        path.join(dir, 'ai_history.jsonl'),
+        JSON.stringify(record) + '\n',
+        'utf8',
+    );
+}
+
+function summariseConflict(c: MergeConflict): string {
+    const note = c.note ? ` — ${c.note}` : '';
+    return `${c.kind} on ${c.type} \`${c.key}\`${note}`;
+}
+
+/** Whether AI residual resolution is currently allowed (HLR-034 gate). */
+export function aiResidualResolutionEnabled(
+    capabilities: AiCapabilityProvider,
+): boolean {
+    if (!capabilities.state().available) {
+        return false;
+    }
+    return getConfig().get<boolean>('merge.aiResidualResolution', true);
+}
+
+export class MergeConflictResolver {
+    constructor(private readonly deps: MergeResolverDeps) {}
+
+    /**
+     * Entry point used by the `projectXml.resolveMergeConflicts`
+     * command and the `/resolve-conflicts` slash command.
+     */
+    async resolve(): Promise<void> {
+        const xmlPath = getProjectXmlPath();
+        const folder = getProjectFolder();
+        if (!xmlPath || !folder) {
+            vscode.window.showWarningMessage(
+                'Project Spec: no Project.xml found in the open workspace.',
+            );
+            return;
+        }
+        if (!getConfig().get<boolean>('merge.enabled', true)) {
+            vscode.window.showInformationMessage(
+                'Project Spec merge is disabled (projectXml.merge.enabled).',
+            );
+            return;
+        }
+        const uri = vscode.Uri.file(xmlPath);
+        if (!(await isConflicted(uri))) {
+            vscode.window.showInformationMessage(
+                'Project Spec: doc/Project.xml is not in a Git merge state.',
+            );
+            return;
+        }
+        const folderFs = folder.uri.fsPath;
+        const relPath = path.relative(folderFs, xmlPath);
+        const [base, ours, theirs] = await Promise.all([
+            gitShowStage(folderFs, relPath, 1),
+            gitShowStage(folderFs, relPath, 2),
+            gitShowStage(folderFs, relPath, 3),
+        ]);
+        if (!ours || !theirs) {
+            vscode.window.showErrorMessage(
+                'Project Spec: could not read ours/theirs stages from Git.',
+            );
+            return;
+        }
+        const xsdPath = getXsdPath();
+        let mergeResult;
+        try {
+            mergeResult = await this.deps.sidecar.mergeThreeWay({
+                base, ours, theirs, xsd_path: xsdPath,
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            vscode.window.showErrorMessage(
+                `Project Spec merge failed: ${msg}`,
+            );
+            return;
+        }
+        if (mergeResult.refused) {
+            vscode.window.showWarningMessage(
+                `Project Spec merge refused: ${mergeResult.refusal ?? 'unknown reason'}. ` +
+                'Falling back to manual conflict-marker resolution.',
+            );
+            return;
+        }
+
+        const residuals: ResidualOutcome[] = [];
+        let mergedXml = mergeResult.merged_xml;
+        const aiOn = aiResidualResolutionEnabled(this.deps.capabilities);
+
+        for (const conflict of mergeResult.residual_conflicts) {
+            const outcome = await this.handleResidual(
+                conflict, mergedXml, aiOn, folderFs,
+            );
+            residuals.push(outcome);
+            if (outcome.decision === 'ai' && outcome.aiPayload) {
+                try {
+                    const sub = await this.deps.sidecar.applyMergeResolution({
+                        merged_xml: mergedXml,
+                        conflict,
+                        resolution: outcome.aiPayload,
+                    });
+                    mergedXml = sub.merged_xml;
+                } catch (err) {
+                    this.deps.output.appendLine(
+                        `[merge] apply_resolution failed for ${conflict.key}: ${
+                            err instanceof Error ? err.message : String(err)
+                        }`,
+                    );
+                }
+            }
+        }
+
+        await this.openMergeEditor(uri, base, ours, theirs, mergedXml,
+            mergeResult.residual_conflicts.length, mergeResult.auto_resolved,
+            residuals);
+    }
+
+    private async handleResidual(
+        conflict: MergeConflict,
+        _mergedXml: string,
+        aiOn: boolean,
+        folderFs: string,
+    ): Promise<ResidualOutcome> {
+        if (!aiOn) {
+            return {
+                conflict, aiPayload: null, rationale: null,
+                intent: null, decision: 'skip',
+            };
+        }
+        const intent = intentForConflict(conflict.kind);
+        const target = targetForConflict(conflict);
+        const userPrompt = renderConflictPrompt(conflict);
+        try {
+            const outcome = await this.deps.aiClient.runIntent({
+                intent, target, userPrompt, autoApply: true,
+            });
+            const r = outcome.result;
+            if (r.kind !== 'merge_resolved' || !r.response) {
+                return {
+                    conflict, aiPayload: null, rationale: null,
+                    intent, decision: 'skip',
+                };
+            }
+            const payload = r.response as Record<string, unknown>;
+            const rationale = typeof payload.rationale === 'string'
+                ? payload.rationale : null;
+            await appendProvenance(folderFs, {
+                kind: 'merge.suggestion',
+                intent,
+                conflict_kind: conflict.kind,
+                conflict_key: conflict.key,
+                base_sha1: sha1(conflict.base),
+                ours_sha1: sha1(conflict.ours),
+                theirs_sha1: sha1(conflict.theirs),
+                rationale,
+                model: outcome.modelId ?? null,
+                ts: new Date().toISOString(),
+            });
+            return {
+                conflict, aiPayload: payload, rationale,
+                intent, decision: 'ai',
+            };
+        } catch (err) {
+            this.deps.output.appendLine(
+                `[merge] AI suggestion failed for ${conflict.key}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return {
+                conflict, aiPayload: null, rationale: null,
+                intent, decision: 'skip',
+            };
+        }
+    }
+
+    /**
+     * Show the merger's output to the user. We write `merged_xml` to a
+     * scratch file and open it side-by-side with the conflicted file
+     * so the user can review and copy in. Falls back to a notification
+     * when the merge editor command surface is unavailable.
+     */
+    private async openMergeEditor(
+        targetUri: vscode.Uri,
+        base: string | null,
+        _ours: string | null,
+        _theirs: string | null,
+        mergedXml: string,
+        residualCount: number,
+        autoResolved: number,
+        outcomes: ResidualOutcome[],
+    ): Promise<void> {
+        const scratchUri = targetUri.with({
+            scheme: 'file',
+            path: targetUri.path + '.tracer-merge.xml',
+        });
+        await fs.writeFile(scratchUri.fsPath, mergedXml, 'utf8');
+        const summary = outcomes.map((o) => {
+            const tag = o.decision === 'ai'
+                ? '✨ AI suggestion'
+                : (o.decision === 'skip' ? '⚠ unresolved' : o.decision);
+            const rat = o.rationale ? ` — ${o.rationale}` : '';
+            return `  - ${summariseConflict(o.conflict)} → ${tag}${rat}`;
+        }).join('\n');
+        this.deps.output.appendLine(
+            `[merge] auto-resolved=${autoResolved} residual=${residualCount}\n${summary}`,
+        );
+        const action = await vscode.window.showInformationMessage(
+            `Project Spec merge: ${autoResolved} auto-resolved, ` +
+                `${residualCount} residual conflicts. Merged candidate ` +
+                `written to ${path.basename(scratchUri.fsPath)}.`,
+            'Open candidate', 'Diff vs. ours', 'Show log',
+        );
+        if (action === 'Open candidate') {
+            const doc = await vscode.workspace.openTextDocument(scratchUri);
+            await vscode.window.showTextDocument(doc);
+        } else if (action === 'Diff vs. ours') {
+            await vscode.commands.executeCommand(
+                'vscode.diff', targetUri, scratchUri,
+                'Project.xml ↔ AI-assisted merge candidate',
+            );
+        } else if (action === 'Show log') {
+            this.deps.output.show();
+        }
+        if (base == null || base.length === 0) {
+            this.deps.output.appendLine(
+                '[merge] note: Git merge base was empty; merger may have refused.',
+            );
+        }
+    }
+}
+
+/** Build the per-region user prompt fed to the merge.* intents. */
+function renderConflictPrompt(c: MergeConflict): string {
+    const sections: string[] = [];
+    sections.push(`Conflict kind: ${c.kind}`);
+    sections.push(`Container: ${c.container}`);
+    sections.push(`Key: ${c.key}`);
+    if (c.note) {
+        sections.push(`Note: ${c.note}`);
+    }
+    if (c.base) {
+        sections.push(`--- BASE ---\n${c.base}`);
+    }
+    if (c.ours) {
+        sections.push(`--- OURS ---\n${c.ours}`);
+    }
+    if (c.theirs) {
+        sections.push(`--- THEIRS ---\n${c.theirs}`);
+    }
+    if (c.rename_to) {
+        sections.push(`Suggested rename: ${c.rename_to}`);
+    }
+    return sections.join('\n\n');
+}

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -135,6 +135,38 @@ export class ProjectIoClient implements vscode.Disposable {
         );
     }
 
+    /**
+     * Phase 5.5 (HLR-063..069): Stage A deterministic three-way merge
+     * over `doc/Project.xml`. The sidecar never writes; the caller is
+     * responsible for opening the merge editor with `mergedXml` and
+     * driving residual conflicts through Stage B (AI or manual).
+     *
+     * `base` may be null/empty when the Git merge base is unavailable;
+     * the sidecar then returns `{ refused: true, refusal: "..." }`
+     * (HLR-034) instead of raising.
+     */
+    async mergeThreeWay(params: MergeThreeWayParams): Promise<MergeThreeWayResult> {
+        return this.request<MergeThreeWayResult>(
+            'merge_three_way',
+            params as unknown as Record<string, unknown>,
+        );
+    }
+
+    /**
+     * Phase 5.5: substitute a Stage-B resolution payload (from a
+     * `merge.*` AI intent or a manual edit) back into the merged
+     * tree. The sidecar still does not write; the merge editor is
+     * the only commit surface (per SDP §5.9).
+     */
+    async applyMergeResolution(
+        params: ApplyMergeResolutionParams,
+    ): Promise<ApplyMergeResolutionResult> {
+        return this.request<ApplyMergeResolutionResult>(
+            'apply_merge_resolution',
+            params as unknown as Record<string, unknown>,
+        );
+    }
+
     private async request<T>(method: string, params: Record<string, unknown>): Promise<T> {
         const proc = this.ensureStarted();
         const id = this.nextId++;
@@ -647,6 +679,7 @@ export type AiResponseKind =
     | 'rejected'
     | 'advisory'
     | 'draft_pvd'
+    | 'merge_resolved'
     | 'no-model';
 
 /** Shape returned by `ai_request`. Matches `pipeline.StepResult.to_dict`. */
@@ -675,3 +708,79 @@ export interface AiRequestResult {
     /** Echo of the parsed model JSON when present. */
     response?: Record<string, unknown>;
 }
+
+// ---------- Phase 5.5: merge_three_way / apply_merge_resolution -------
+
+export type MergeConflictKind =
+    | 'body'
+    | 'modify_delete'
+    | 'id_collision'
+    | 'trace'
+    | 'schema_bump';
+
+/** A residual structural conflict surfaced by `merge_three_way`. */
+export interface MergeConflict {
+    kind: MergeConflictKind;
+    /** XPath-ish container of the conflicting payload (e.g.
+     *  `/hlrs/section[@number='1']/hlr[@id='HLR-001']`). */
+    container: string;
+    /** Stable identifier of the conflicting item (e.g. `HLR-001`,
+     *  `tools/foo.py`, or `schema_version` for `kind='schema_bump'`). */
+    key: string;
+    /** Complex-type name of the payload (e.g. `"Hlr"`). */
+    type: string;
+    /** Serialised XML for the three sides; null when missing on
+     *  that branch (modify-vs-delete). */
+    base: string | null;
+    ours: string | null;
+    theirs: string | null;
+    /** For `kind='id_collision'`: the auto-allocated id the merger
+     *  proposes for the theirs side. */
+    rename_to?: string;
+    /** Optional human-readable note from the merger (e.g. divergent
+     *  child tags). */
+    note?: string;
+}
+
+export interface MergeLintSummary {
+    errors: string[];
+    warnings: string[];
+    notes: string[];
+    ok: boolean;
+}
+
+export interface MergeThreeWayParams {
+    /** Pre-conflict ancestor XML; pass null/empty when the Git merge
+     *  base is unavailable — the sidecar refuses cleanly (HLR-034). */
+    base: string | null;
+    ours: string;
+    theirs: string;
+    xsd_path?: string;
+}
+
+export interface MergeThreeWayResult {
+    merged_xml: string;
+    residual_conflicts: MergeConflict[];
+    lint: MergeLintSummary;
+    /** Number of conflicts the merger auto-resolved structurally
+     *  (disjoint adds, trace unions, one-sided edits, etc.). */
+    auto_resolved: number;
+    /** True when the merger refused to run; `refusal` carries the
+     *  human-readable reason. */
+    refused: boolean;
+    refusal?: string;
+}
+
+export interface ApplyMergeResolutionParams {
+    merged_xml: string;
+    conflict: MergeConflict;
+    /** Stage-B payload — schema depends on the intent that produced
+     *  it (e.g. `{ merged_xml: string }` for `merge.body`,
+     *  `{ schema_version: string }` for `merge.schema_bump`). */
+    resolution: Record<string, unknown>;
+}
+
+export interface ApplyMergeResolutionResult {
+    merged_xml: string;
+}
+

--- a/tools/vscode-project-xml/test/unit/aiIntents.test.ts
+++ b/tools/vscode-project-xml/test/unit/aiIntents.test.ts
@@ -14,7 +14,7 @@ describe('ai/intents', () => {
         for (const i of INTENTS) {
             assert.ok(i.id, `intent missing id`);
             assert.ok(i.label, `intent ${i.id} missing label`);
-            assert.match(i.kind, /^(authoring|pvd|advisory)$/);
+            assert.match(i.kind, /^(authoring|pvd|advisory|merge)$/);
             assert.ok(i.slash, `intent ${i.id} missing slash`);
         }
     });
@@ -30,6 +30,10 @@ describe('ai/intents', () => {
             'expand.hlr_to_llrs',
             'expand.llr_to_tests',
             'gap.fix',
+            'merge.body',
+            'merge.rename',
+            'merge.schema_bump',
+            'merge.trace',
             'review.item',
             'suggest.traces',
         ]);
@@ -42,6 +46,7 @@ describe('ai/intents', () => {
             'draft-test',
             'expand',
             'gap-fill',
+            'resolve-conflicts',
             'review',
             'suggest-traces',
         ]);


### PR DESCRIPTION
Python:
- tools/project_merge.py: deterministic three-way structural merger (lxml-based; preserves comments/CDATA/attribute order; unions disjoint adds and <traces>; reallocates colliding ids; recomputes <metadata>/<counts>; refuses cleanly on missing merge base per HLR-034).
- tools/project_io.py: merge_three_way + apply_merge_resolution JSON-RPC methods.
- tools/ai/{registry,pipeline}.py: 4 merge intents (merge.body, merge.trace, merge.rename, merge.schema_bump) with kind=merge skipping the apply_edit path.
- tools/ai/intents/merge.*.md + tools/ai/schemas/merge.*.json.
- test/test_project_merge.py: 17 tests covering clean merges, id collisions, body conflicts, modify-delete, schema bumps, counts recomputation, apply_resolution, JSON-RPC surface, intent registry.
- 140/140 Python tests green.

TypeScript:
- src/sidecar.ts: mergeThreeWay + applyMergeResolution wrappers and MergeConflict / MergeResult types.
- src/merge/MergeConflictResolver.ts: detects MERGE state via the git extension API, fetches :1/:2/:3 via git show, drives Stage A, drives merge.* intents per residual, substitutes via apply_merge_resolution, writes a scratch candidate file, and offers open/diff/log actions. Never writes Project.xml automatically.
- src/commands/resolveMerge.ts: registers projectXml.resolveMergeConflicts.
- src/ai/{intents,participant}.ts: 4 merge intents mirrored; /resolve-conflicts slash command added.
- Per-region provenance to .edit_doc/ai_history.jsonl with sha-1 hashes of base/ours/theirs, intent id, and rationale.
- package.json: command + chat command + settings projectXml.merge.{enabled,aiResidualResolution} (the latter forced off when projectXml.ai.enabled=false per HLR-034).
- 149/149 TS unit tests green; tsc clean.

Docs:
- doc/Project.xml: function 28 'merge' with LLR-MRG-01..08 tracing HLR-034..036, plus 17 <test> rows. Lint: 0 errors.
- Re-rendered SDD/HLRs/LLRs/STP/Traceability.
- README.md: Phase 5.5 status -> Done; settings table + repo layout updated.