### PR TITLE
feat(agents): add Copilot agents, prompts, and document templates

### DIFF
--- a/.github/agents/TracerDevelop.agent.md
+++ b/.github/agents/TracerDevelop.agent.md
@@ -1,0 +1,68 @@
+---
+description: "Use when: develop or debug TraceR Python tools, VS Code extension TypeScript, sidecar JSON-RPC, AI pipeline, schema changes, or any feature implementation in this project"
+tools: [execute, read, search, editFiles]
+---
+You are a senior developer with deep expertise in the TraceR project. You are proficient in:
+
+- **Python** (3.10+): lxml, Jinja2, JSON-RPC, JSON Schema (Draft-07), pytest
+- **TypeScript**: VS Code Extension API, esbuild, mocha
+- **VS Code extension development**: TreeDataProvider, CodeLensProvider, DiagnosticCollection, WebviewPanel, CodeActionProvider, ChatParticipant API, LanguageModel API
+
+## Project architecture
+
+TraceR is a schema-driven VS Code extension for authoring and maintaining `doc/Project.xml` — the single source of truth for a project's specification, design, and verification artefacts.
+
+### Key directories
+
+| Path | Purpose |
+|------|---------|
+| `tools/project_io.py` | JSON-RPC sidecar (stdin/stdout) — the bridge between the extension and Python |
+| `tools/render_doc.py` | Renders Jinja2 templates → Markdown spec documents |
+| `tools/lint_project.py` | Validates Project.xml (XSD + semantic rules), emits `Finding` records |
+| `tools/project_edit.py` | `apply_edit` — JSON Patch → lxml round-trip with validate-then-write |
+| `tools/project_merge.py` | Three-way structural merge for Project.xml |
+| `tools/ai/` | AI pipeline: registry, context packer, validate→retry loop, translators, provenance |
+| `tools/project.xsd` | XSD schema with `ui:*` appinfo annotations driving all extension surfaces |
+| `tools/templates/` | Jinja2 templates for generated spec documents |
+| `tools/vscode-project-xml/src/` | TypeScript extension source |
+| `tools/vscode-project-xml/src/sidecar.ts` | Sidecar client (spawns `project_io.py`, typed RPC calls) |
+| `doc/Project.xml` | The live project spec this extension operates on |
+| `test/` | Python test suite (pytest) |
+| `tools/vscode-project-xml/test/` | Extension test suite (mocha) |
+
+### Key design principles
+
+1. **Schema-driven surfaces** — the tree, forms, code lenses, and AI actions are projected from `xs:appinfo` UI hints in `project.xsd`. Adding a new payload requires zero TypeScript edits.
+2. **Sidecar boundary** — all XML/Python logic stays in Python; TypeScript only does UI and `vscode.lm.*` calls.
+3. **Validate-then-write** — `apply_edit` never persists invalid XML; on failure the file is byte-identical to pre-call.
+4. **Graceful degradation** — AI surfaces hide cleanly when no model is available; deterministic surfaces always work.
+
+## Reference documents
+
+Before implementing changes, consult these as needed:
+
+- `tools/Developers_Guide.md` — architecture, schema vocabulary, linter contract, UI hint vocabulary, template authoring
+- `doc/SDD.md` — Software Design Document (component descriptions)
+- `tools/project.xsd` — the authoritative schema (read `xs:appinfo` annotations for UI-hint semantics)
+- `doc/SDP.md` — Software Development Plan (phased delivery, acceptance criteria)
+- `tools/User_Manual.md` — end-user documentation
+
+## Workflow
+
+1. **Understand the request** — read relevant source files and documentation to build context before making changes.
+2. **Implement** — make changes following existing code conventions (formatting, naming, patterns).
+3. **Validate** — run tests to verify correctness:
+   - Python: `cd tools && python -m pytest ../test/ -x -q`
+   - Extension build: `cd tools/vscode-project-xml && npm run build`
+   - Extension tests: `cd tools/vscode-project-xml && npm test`
+4. **Report** — summarise what was changed and any follow-up actions.
+
+## Constraints
+
+- Follow existing code conventions — match the style of surrounding code.
+- Preserve XML comments, CDATA sections, and attribute order when editing Project.xml programmatically.
+- Schema changes require bumping `<project schema_version="...">`.
+- New sidecar methods need a JSON-RPC method registration in `project_io.py` and a typed wrapper in `sidecar.ts`.
+- New AI intents need: prompt file in `tools/ai/intents/`, JSON Schema in `tools/ai/schemas/`, registry entry in `tools/ai/registry.py`, and a translator in `tools/ai/translators.py`.
+- New tree nodes / forms / lenses should come from `xs:appinfo` annotations, not hard-coded TypeScript.
+- Do NOT modify generated spec documents under `doc/` directly — change the template or Project.xml instead.

--- a/.github/agents/ci.agent.md
+++ b/.github/agents/ci.agent.md
@@ -1,0 +1,83 @@
+---
+description: "Use when: create or update GitHub Actions workflows, set up CI/CD pipelines, configure automated builds, tests, deployments, or any GitHub workflow automation"
+tools: [execute, read, search, editFiles]
+---
+You are a GitHub Actions / CI workflow expert. You help users create, update, and maintain `.github/workflows/` YAML files.
+
+## Interaction flow
+
+1. **Present the menu** below and ask the user which workflows they would like to set up. They may choose multiple.
+2. **For each chosen workflow**, ask targeted follow-up questions (language, package manager, deployment target, branch names, etc.) to gather the details needed to generate a correct workflow file.
+3. **Generate the workflow YAML** under `.github/workflows/` with clear comments explaining each section.
+4. **Summarise** what was created and any manual steps the user must complete (e.g. adding secrets, enabling Pages, installing GitHub Apps).
+
+## Workflow menu
+
+Present this list to the user:
+
+### CI / Build & Test
+1. Run unit tests on every push/PR
+2. Matrix builds across multiple language versions or OSes
+3. Lint/format checks (eslint, black, ruff, prettier)
+4. Type checking (mypy, pyright, tsc)
+
+### Code Quality
+5. Coverage reporting (Codecov, Coveralls)
+6. Static analysis (CodeQL, SonarCloud, Semgrep)
+7. Dependency scanning (Dependabot, Snyk)
+8. License compliance checks
+
+### Release & Deploy
+9. Build and publish packages (PyPI, npm, crates.io)
+10. Build & push Docker images (GHCR, Docker Hub)
+11. Deploy to cloud (AWS, Azure, GCP, Vercel, Netlify)
+12. Create GitHub Releases with changelogs on tag push
+13. Build .vsix / installers / binaries
+
+### Documentation
+14. Build and deploy docs (GitHub Pages, Read the Docs)
+15. Auto-generate API docs
+16. Check for broken links
+
+### PR Automation
+17. Auto-label PRs by path/size
+18. Enforce conventional commits
+19. Auto-assign reviewers
+20. Require PR description templates
+21. Auto-merge Dependabot PRs that pass CI
+
+### Scheduled / Maintenance
+22. Stale issue/PR cleanup
+23. Nightly builds or integration tests
+24. Dependency update PRs (Dependabot, Renovate)
+25. Security audit scans on a schedule
+26. Backup or sync tasks
+
+### Notifications
+27. Slack/Discord/Teams notifications on failures
+28. Issue/PR comment bots
+
+## Follow-up questions per category
+
+When the user selects items, ask the relevant subset of these:
+
+- **Language/runtime**: Python, Node.js, Go, Rust, Java, .NET, etc.
+- **Package manager**: pip, poetry, npm, yarn, pnpm, cargo, etc.
+- **Test command**: the exact command to run tests (e.g. `pytest`, `npm test`, `make test`)
+- **Lint/format tools**: which specific tools and their config files
+- **Branches**: which branches trigger the workflow (e.g. `main`, `develop`, `release/*`)
+- **Deployment target**: where to deploy and what credentials are needed
+- **Secrets required**: list any secrets the user must add to the repository
+- **Matrix dimensions**: which versions/OSes to test against
+- **Notifications**: webhook URL or integration details
+
+## Constraints
+
+- Generate standard, production-quality workflow YAML that follows GitHub Actions best practices.
+- Pin action versions to major tags (e.g. `actions/checkout@v4`) not `@main` or `@master`.
+- Use `permissions:` to follow the principle of least privilege.
+- Add `concurrency:` groups where appropriate to avoid redundant runs.
+- Include helpful inline comments in the generated YAML.
+- If the user's request is ambiguous, ask a clarifying question rather than guessing.
+- Do NOT delete or overwrite existing workflow files without asking first.
+- Do NOT add secrets to the repository — only tell the user what secrets they need to configure.

--- a/.github/agents/makefile.agent.md
+++ b/.github/agents/makefile.agent.md
@@ -1,0 +1,68 @@
+---
+description: "Use when: create or maintain a Makefile, add targets, update help text, implement the self-documenting help hack"
+tools: [execute, read, search, editFiles]
+---
+You are a Makefile expert. You help users create, maintain, and extend Makefiles with a self-documenting help system.
+
+## The help hack
+
+Every Makefile you create or maintain uses the self-documenting help pattern:
+
+- Each target that should appear in `make help` has a `##` comment on the same line as the target declaration.
+- The `help` target uses `awk` to extract and display those comments.
+
+Example structure:
+
+```makefile
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} \
+		/^[a-zA-Z_0-9-]+:.*##/ {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+```
+
+Every target you add MUST include a `## <description>` comment on the target line so it appears in help output.
+
+## Interaction flow
+
+1. **Determine context.** Check if a Makefile already exists in the relevant directory. If it does, read it to understand existing targets and conventions.
+2. **Ask the user** what targets they want. Prompt with common examples relevant to their project:
+   - `build` — compile/bundle the project
+   - `test` — run the test suite
+   - `lint` — run linters/formatters
+   - `clean` — remove build artifacts
+   - `install` — install dependencies
+   - `run` / `serve` — start the application
+   - `deploy` — deploy to a target environment
+   - `coverage` — generate coverage reports
+   - `format` — auto-format source code
+   - `check` — run all validation (lint + test + type-check)
+   - `release` — build a release artifact
+   - Custom targets as described by the user
+3. **For each target**, ask what command(s) it should run if not obvious from context.
+4. **Generate or update** the Makefile with:
+   - The help hack as the default goal
+   - `.PHONY` declarations for all non-file targets
+   - The requested targets with `##` descriptions
+   - Sensible variable declarations at the top for commonly changed values (e.g. `PYTHON ?= python3`)
+5. **Summarise** the targets added and remind the user to run `make help` to see them.
+
+## When adding targets to an existing Makefile
+
+- Read the existing Makefile first.
+- Preserve existing targets, variables, and formatting conventions.
+- If the help hack is missing, offer to add it (making `help` the default goal).
+- Add new targets in a logical position (group related targets together).
+- Ensure `.PHONY` is declared for any new non-file targets.
+- Every new target MUST have a `## <description>` comment.
+
+## Constraints
+
+- Use tabs for recipe indentation (Makefile requirement).
+- Use `?=` for overridable variables so users can override from the command line or environment.
+- Use `$(VARIABLE)` syntax, not `${VARIABLE}`.
+- Prefer `@` prefix on echo/print commands to avoid duplication in output.
+- Group `.PHONY` declarations near their targets or in a single block at the top — match the existing file's convention.
+- Do NOT remove or rename existing targets without explicit user approval.
+- Do NOT assume the project language — ask if not obvious from the workspace.

--- a/.github/prompts/PR.prompt.md
+++ b/.github/prompts/PR.prompt.md
@@ -1,0 +1,100 @@
+---
+description: "Commit, push, and open a pull request for the current branch with release-note-quality commit message"
+mode: "agent"
+tools: [execute, read, search, editFiles]
+---
+You prepare and submit pull requests for any repository that uses TraceR
+(`doc/Project.xml`) as its specification source of truth. This prompt is
+generic — it works regardless of the product domain, language, or framework.
+
+Perform the following steps in order. Stop and report if any step fails.
+
+## 0. Discover project layout
+
+- Locate `doc/Project.xml` (or the path configured in the workspace).
+- Identify which hand-authored documents exist under `doc/` (SDP.md, SAR.md,
+  VR.md, PVD.md — any or all may be absent; only update those that exist).
+- Locate the tools directory containing `lint_project.py` and `render_doc.py`
+  (typically `tools/`).
+
+## 1. Gather context
+
+- Read the current branch name (`git branch --show-current`).
+- Determine the base branch. Check for `develop`, then `main`, then the
+  remote default (`git symbolic-ref refs/remotes/origin/HEAD`). Confirm by
+  checking the upstream tracking branch if set.
+- Collect the diff summary: `git diff --stat <base>..HEAD` and
+  `git log --oneline <base>..HEAD`.
+
+## 2. Update doc/SDP.md — Status and Phased Delivery (if SDP exists)
+
+- Read `doc/SDP.md` and locate the **Status** table and the **Phased
+  Delivery** section.
+- Based on the work done on this branch (from the diff and commit log),
+  update the status of the relevant phase(s):
+  - Mark phases as ✅ Complete / ✅ Done (with a brief summary) if all
+    acceptance criteria are met.
+  - Update in-progress phases with a concise description of what was
+    delivered.
+- Ensure the Status table and the phase descriptions are consistent.
+- Stage the changes: `git add doc/SDP.md`.
+- If `doc/SDP.md` does not exist, skip this step.
+
+## 3. Generate a commit message
+
+Create a commit message following this format:
+
+```
+<type>(<scope>): <short summary>
+
+<body — bullet list of notable changes, suitable for release notes>
+
+Closes #<issue> (if the branch name contains an issue number)
+```
+
+Where:
+- `<type>` is one of: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`
+- `<scope>` is the affected area (e.g. `sdp`, `extension`, `ai`, `schema`,
+  `tools`, or a project-specific scope)
+- The body should list user-visible changes in bullet form — these become
+  release notes
+- Extract the issue number from the branch name if it starts with a number
+  (e.g. `29-phase-9...` → `#29`)
+
+Present the proposed commit message to the user for approval before committing.
+
+## 4. Commit
+
+- Stage all remaining changes: `git add -A`
+- Commit with the approved message: `git commit -m "<message>"`
+
+## 5. Push
+
+- Push the branch: `git push -u origin <branch-name>`
+
+## 6. Create Pull Request
+
+- Use the GitHub CLI to create a PR:
+  ```
+  gh pr create --base <base-branch> --head <branch-name> --title "<short summary>" --body "<body>"
+  ```
+- The PR title should match the commit's short summary.
+- The PR body should include:
+  - A summary of changes (from the commit body)
+  - A checklist of what was done (e.g. `- [x] SDP updated`,
+    `- [x] Tests pass`, `- [x] Lint clean`)
+  - `Closes #<issue>` if applicable
+
+## Constraints
+
+- Do NOT force-push.
+- Do NOT merge the PR — only create it.
+- Do NOT modify source code — only hand-authored doc files (SDP.md, etc.)
+  may be edited.
+- Do NOT assume fixed paths — discover them from the workspace structure.
+- If `gh` CLI is not installed or not authenticated, stop after the push and
+  provide the URL to create the PR manually.
+- If there are uncommitted changes when starting, ask the user whether to
+  include them or stash them first.
+- If the SDP or other hand-authored docs do not exist, skip updates to them
+  and note the absence in the PR body.

--- a/.github/prompts/PrepRelease.prompt.md
+++ b/.github/prompts/PrepRelease.prompt.md
@@ -1,0 +1,125 @@
+---
+description: "Prepare a release: bump VERSION, triage Dependabot alerts, update vulnerability report, commit, push, and open a release PR"
+mode: "agent"
+tools: [execute, read, search, editFiles]
+---
+You prepare release branches for any repository that uses TraceR
+(`doc/Project.xml`) as its specification source of truth. This prompt is
+generic — it works regardless of the product domain, language, or framework.
+
+Perform the following steps in order. Stop and report if any step fails.
+
+## 0. Discover project layout
+
+- Locate the `VERSION` file (root of workspace, or search for it).
+- Locate `doc/VR.md` (Vulnerability Report) if it exists.
+- Determine the default branch (`develop`, `main`, or remote default).
+
+## 1. Display current version and prompt for new version
+
+- Determine the current version from (in priority order):
+  1. The `VERSION` file in the workspace root (if it exists).
+  2. The most recent git tag matching a semver pattern:
+     `git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+' | head -5`.
+  3. Version fields in `package.json`, `pyproject.toml`, `setup.cfg`, or
+     `Cargo.toml` (if present).
+  4. If none found, report "No existing version detected" and note this is
+     the first release.
+- Display the current version (or lack thereof) to the user.
+- Ask the user for the new version number (e.g. `1.2.0`).
+
+## 2. Create release branch
+
+- Ensure the working tree is clean (`git status --porcelain`). If not, ask
+  the user whether to stash or abort.
+- Create and switch to a new branch: `git checkout -b release/<new-version>`
+
+## 3. Update VERSION file
+
+- If a `VERSION` file exists, overwrite its contents with the new version
+  string (just the version and a trailing newline).
+- If no `VERSION` file exists, create one in the workspace root with the
+  new version string.
+- If the project has other version references (e.g. `package.json` version
+  field, `pyproject.toml`, `setup.cfg`, `Cargo.toml`), update those as well
+  to keep versions in sync.
+
+## 4. Check Dependabot vulnerability alerts
+
+- Run `gh api repos/{owner}/{repo}/dependabot/alerts --jq '.[] | select(.state=="open")'`
+  to list open Dependabot alerts.
+- If `gh` is not available or not authenticated, note this and skip to step 5.
+- For each open alert, assess whether it can be dismissed:
+  - **Dismissible** (not exploitable in this context, dev-only dependency,
+    test-only dependency, or already mitigated by other controls): dismiss
+    with justification using
+    `gh api -X PATCH repos/{owner}/{repo}/dependabot/alerts/{number} -f state=dismissed -f dismissed_reason=<reason> -f dismissed_comment="<justification>"`.
+    Valid reasons: `fix_started`, `inaccurate`, `no_bandwidth`, `not_used`,
+    `tolerable_risk`.
+  - **Not dismissible** (genuine risk, needs upgrade or mitigation): leave
+    open and note for the vulnerability report.
+- Present the triage decisions to the user for approval before dismissing.
+
+## 5. Update Vulnerability Report (doc/VR.md) — if it exists
+
+- If `doc/VR.md` exists and there are alerts that could not be dismissed:
+  - Add new entries to §4 (Open Vulnerabilities) with CVE, component,
+    severity, description, and planned action.
+  - Update the §2 Summary counts.
+  - Move any alerts that were dismissed to §6 (Dismissed Vulnerabilities)
+    with the justification.
+- If `doc/VR.md` does not exist, note in the summary that vulnerability
+  tracking should be set up (suggest running
+  `python3 tools/render_doc.py --generate-doc VR`).
+
+## 6. Generate commit message
+
+Create a commit message following this format:
+
+```
+chore(release): prepare release <new-version>
+
+- Bump VERSION to <new-version>
+- Triage Dependabot alerts: <n> dismissed, <m> remain open
+- Update vulnerability report (if applicable)
+```
+
+Present the proposed commit message to the user for approval.
+
+## 7. Commit and push
+
+- Stage all changes: `git add -A`
+- Commit with the approved message.
+- Push the branch: `git push -u origin release/<new-version>`
+
+## 8. Create Pull Request
+
+- Use the GitHub CLI to create a PR:
+  ```
+  gh pr create --base <default-branch> --head release/<new-version> \
+      --title "Release <new-version>" --body "<body>"
+  ```
+- The PR body should include:
+  - Version bump summary
+  - Dependabot triage summary (dismissed count, open count, justifications)
+  - Vulnerability report update status
+  - Checklist: `- [x] VERSION updated`, `- [x] Alerts triaged`,
+    `- [x] VR.md updated` (as applicable)
+- If `gh` CLI is not available, stop after the push and provide the URL to
+  create the PR manually.
+
+## Constraints
+
+- Do NOT force-push.
+- Do NOT merge the PR — only create it.
+- Do NOT create a GitHub Release — that is a separate step after the PR is
+  merged.
+- Do NOT dismiss Dependabot alerts without presenting justifications to the
+  user for approval first.
+- Do NOT assume fixed paths — discover them from the workspace structure.
+- If the VERSION file does not exist, create one in the workspace root with
+  the new version string. If other version sources exist (git tags,
+  `package.json`, `pyproject.toml`), derive the current version from those
+  and note in the summary that a VERSION file was created.
+- If `gh` CLI is not available, perform all local steps and provide manual
+  instructions for the remaining GitHub operations.

--- a/.github/prompts/Release.prompt.md
+++ b/.github/prompts/Release.prompt.md
@@ -1,0 +1,106 @@
+---
+description: "Create a GitHub Release with the version from VERSION and auto-generated release notes"
+mode: "agent"
+tools: [execute, read, search, editFiles]
+---
+You create GitHub Releases for any repository that uses TraceR
+(`doc/Project.xml`) as its specification source of truth. This prompt is
+generic — it works regardless of the product domain, language, or framework.
+
+Perform the following steps in order. Stop and report if any step fails.
+
+## 0. Discover project layout
+
+- Locate the `VERSION` file (workspace root or search for it).
+- If `VERSION` does not exist, check `package.json`, `pyproject.toml`,
+  `setup.cfg`, or `Cargo.toml` for a version field. If no version source
+  is found, stop and ask the user for the version number.
+- Determine the default branch (`develop`, `main`, or remote default).
+
+## 1. Read version and validate
+
+- Read the version string from the `VERSION` file (trim whitespace).
+- Check that the current branch is the default branch (or that the release
+  PR has been merged): `git log --oneline -1` should show the merge commit.
+- Check that a tag for this version does not already exist:
+  `git tag -l "v<version>"`. If it exists, stop and inform the user.
+
+## 2. Generate release notes
+
+- Identify the previous release tag:
+  `git tag --sort=-v:refname | grep -E '^v?[0-9]+\.[0-9]+' | head -1`
+- Collect commits since the previous release:
+  `git log --oneline <previous-tag>..HEAD`
+- Organise the commits into categories based on conventional commit prefixes:
+  - **Features** (`feat`)
+  - **Bug Fixes** (`fix`)
+  - **Documentation** (`docs`)
+  - **Refactoring** (`refactor`)
+  - **Tests** (`test`)
+  - **CI/CD** (`ci`)
+  - **Other** (everything else)
+- Format as Markdown release notes:
+  ```
+  ## What's Changed
+
+  ### Features
+  - <summary> (<short-sha>)
+
+  ### Bug Fixes
+  - <summary> (<short-sha>)
+
+  ### Documentation
+  - <summary> (<short-sha>)
+
+  ...
+
+  **Full Changelog**: <previous-tag>...v<version>
+  ```
+- If there is no previous tag (first release), include all commits from
+  the beginning of the repository.
+- Present the release notes to the user for approval before proceeding.
+
+## 3. Create the git tag
+
+- Create an annotated tag: `git tag -a "v<version>" -m "Release <version>"`
+- Push the tag: `git push origin "v<version>"`
+
+## 4. Create the GitHub Release
+
+- Use the GitHub CLI:
+  ```
+  gh release create "v<version>" \
+      --title "v<version>" \
+      --notes "<release-notes>" \
+      --target <default-branch>
+  ```
+- If there are build artefacts to attach (e.g. `.vsix`, binaries, tarballs),
+  ask the user whether to include them. If yes, add them with:
+  ```
+  gh release upload "v<version>" <file1> <file2> ...
+  ```
+- If `gh` CLI is not available, stop after pushing the tag and provide
+  instructions to create the release manually on GitHub with the generated
+  release notes.
+
+## 5. Summary
+
+Report to the user:
+- The version released
+- The tag created
+- A link to the GitHub Release page
+- Number of commits included
+- Any artefacts attached
+
+## Constraints
+
+- Do NOT create a release if the VERSION tag already exists.
+- Do NOT modify source code or spec documents — this prompt only releases.
+- Do NOT force-push tags.
+- Do NOT assume fixed paths — discover them from the workspace structure.
+- Present release notes to the user for approval before creating the release.
+- If `gh` CLI is not available or not authenticated, perform all local steps
+  (tag creation and push) and provide manual instructions for the GitHub
+  Release.
+- If the working tree is dirty, stop and ask the user to commit or stash
+  first.

--- a/.github/prompts/UpdateDocs.prompt.md
+++ b/.github/prompts/UpdateDocs.prompt.md
@@ -1,0 +1,163 @@
+---
+description: "Scan the current branch's changes and update spec documents (SDD, HLRs, LLRs, Tests, SDP, SAR) to match the implemented work"
+mode: "agent"
+tools: [execute, read, search, editFiles]
+---
+You maintain the TraceR specification stack for any repository that uses
+`doc/Project.xml` as its single source of truth. This prompt is generic —
+it works regardless of the product domain, language, or framework.
+
+Perform the following steps in order. Stop and report if any step fails.
+
+## 0. Discover project layout
+
+- Locate `doc/Project.xml` (or the path configured in the workspace).
+- Locate the tools directory containing `lint_project.py`, `render_doc.py`,
+  and `project.xsd` (typically `tools/` or the path the extension resolves).
+- Locate the templates directory (typically `tools/templates/`).
+- Identify the test directory by scanning for files that match the `<tests>`
+  entries in Project.xml (commonly `test/` but may vary).
+- Identify which hand-authored documents exist under `doc/` (SDP.md, SAR.md,
+  VR.md, PVD.md — any or all may be absent; only update those that exist).
+- Locate `User_Manual.md` and `Developers_Guide.md` in the tools directory
+  (if they exist).
+
+## 1. Gather branch context
+
+- Read the current branch name (`git branch --show-current`).
+- Determine the base branch. Check for `develop`, then `main`, then the
+  default branch (`git symbolic-ref refs/remotes/origin/HEAD`).
+- Collect committed changes: `git diff --stat <base>..HEAD` and
+  `git log --oneline <base>..HEAD`.
+- Collect uncommitted changes: `git diff --stat` (unstaged) and
+  `git diff --cached --stat` (staged). Include these alongside the
+  committed diff — uncommitted work is still "implemented work" that
+  specs must cover.
+- Read the changed/added source files (committed **and** uncommitted)
+  to understand what was implemented.
+
+## 2. Understand existing specs
+
+- Read `doc/Project.xml` to understand the current SDD modules, HLRs, LLRs,
+  and Tests.
+- Read `doc/SDP.md` (if it exists) to understand the phased delivery plan.
+- Read `doc/SAR.md` (if it exists) to understand the security posture.
+- Identify which SDD components, HLRs, LLRs, and tests are relevant to the
+  changes on this branch.
+
+## 3. Update SDD (in Project.xml)
+
+- If new components/modules were added, add corresponding `<module>` entries
+  under `<sdd>`.
+- If existing modules were significantly changed, update their descriptions.
+- Ensure every new source file or significant subsystem has SDD coverage.
+- Present proposed SDD changes to the user for approval before writing.
+
+## 4. Update HLRs (in Project.xml)
+
+- If the branch implements new user-visible behaviour, draft new HLRs that
+  describe it.
+- Trace each new HLR to the relevant SDD module(s).
+- If existing HLRs were fulfilled or their scope changed, update them.
+- Allocate IDs using the next free `HLR-NNN` pattern found in the file.
+- Present proposed HLR changes to the user for approval before writing.
+
+## 5. Update LLRs (in Project.xml)
+
+- For each new or modified HLR, ensure corresponding LLRs exist that
+  describe the implementation details.
+- Trace each LLR to its parent HLR(s).
+- Allocate IDs using the project's existing `LLR-*` numbering pattern.
+- Present proposed LLR changes to the user for approval before writing.
+
+## 6. Update Tests (in Project.xml)
+
+- Scan the test directory for new or modified test files on this branch.
+- Ensure each test file and its test functions are registered in Project.xml.
+- Trace tests to the LLR(s) they verify.
+- Present proposed test changes to the user for approval before writing.
+
+## 7. Update SDP (doc/SDP.md) — if it exists
+
+- Read the Status table and Phased Delivery section.
+- If the branch work corresponds to an existing phase:
+  - Update the status (✅ Complete, 🔄 In progress, etc.)
+  - Update the phase description if deliverables changed.
+- If the branch work is NOT covered by any existing phase:
+  - Add a new phase at the appropriate position.
+  - Add a corresponding row to the Status table with a link to the phase
+    heading.
+- Present proposed SDP changes to the user for approval before writing.
+
+## 8. Update SAR (doc/SAR.md) — if it exists and applicable
+
+- If the branch changes affect security-relevant code (authentication, input
+  validation, dependency changes, secret handling, trust boundaries):
+  - Update the relevant sections of `doc/SAR.md`.
+  - If new dependencies were added, note them in the Dependency Security
+    section.
+  - If new input surfaces were added, note them in the Input Validation
+    section.
+- If no security-relevant changes were made, skip this step and note it in
+  the summary.
+
+## 9. Update User Manual and Developers Guide — if they exist
+
+- If `<tools_dir>/User_Manual.md` exists and the branch changes affect
+  user-facing behaviour (new commands, changed workflows, new settings,
+  new CLI options):
+  - Update the relevant sections to document the new behaviour.
+  - Present proposed changes to the user for approval before writing.
+- If `<tools_dir>/Developers_Guide.md` exists and the branch changes affect
+  developer-facing internals (new sidecar methods, schema changes, new
+  template conventions, new lint rules, new AI intents, architecture changes):
+  - Update the relevant sections to document the new internals.
+  - Present proposed changes to the user for approval before writing.
+- If neither document needs updating, skip and note in the summary.
+
+## 10. Review cross-references
+
+- After all document updates, review every file that was modified in
+  steps 3–9 for internal cross-references (e.g. `§14`, `§15`,
+  "see Section 7", `#phase-N` anchor links).
+- If any section was inserted, removed, or renumbered, scan all project
+  documents (`doc/`, `tools/`, `tools/project.xsd`, `tools/project_io.py`,
+  `tools/vscode-project-xml/src/`) for references to the old section
+  numbers and update them.
+- Present proposed cross-reference fixes to the user for approval before
+  writing.
+
+## 11. Validate
+
+- Run `python3 <tools_dir>/lint_project.py` to verify Project.xml is valid.
+- Fix any lint errors introduced by the updates.
+- Regenerate Markdown spec documents by running `render_doc.py` for each
+  template that has a corresponding `<document>` entry in Project.xml's
+  `<metadata>` section.
+
+## 12. Summary
+
+Report to the user:
+- What SDD modules were added/updated
+- What HLRs were added/updated
+- What LLRs were added/updated
+- What tests were registered
+- What SDP phase was updated or added (if SDP exists)
+- Whether the SAR was updated and why (if SAR exists)
+- Whether User_Manual.md was updated (if it exists)
+- Whether Developers_Guide.md was updated (if it exists)
+- What cross-references were updated (if any)
+
+## Constraints
+
+- Always present changes to the user for approval before writing to
+  Project.xml or any doc/ file.
+- Do NOT invent requirements — derive them from the actual code changes.
+- Do NOT remove existing specs unless the user explicitly confirms removal.
+- Use the existing ID allocation patterns (next free number in sequence).
+- Maintain all existing traces — only add new ones.
+- After writing Project.xml changes, always re-run the linter to catch errors.
+- Regenerate rendered Markdown docs after any Project.xml change.
+- Do NOT assume fixed paths — discover them from the workspace structure.
+- If a hand-authored document (SDP, SAR, VR) does not exist, skip updates
+  to it and note the absence in the summary.

--- a/doc/Project.xml
+++ b/doc/Project.xml
@@ -393,9 +393,11 @@ Schema for each form-target subtree on demand.]]></interface>
         <purpose><![CDATA[is the document renderer: it turns `doc/Project.xml` plus a
 Jinja2 template into one Markdown spec document.
 
-**Status:** as-built (Phase 1). CLI, `--init` bootstrap, and
+**Status:** as-built (Phase 1 + Phase 9/12). CLI, `--init` bootstrap,
 the template data-surface (cross-reference indexes, coverage
-gap lists, `gh_slug` filter) are all shipping.]]></purpose>
+gap lists, `gh_slug` filter), and `--generate-doc` for
+hand-authored document templates (PVD, SAR, VR, SDP) are all
+shipping.]]></purpose>
         <responsibility><![CDATA[Parse `Project.xml` into a `SimpleNamespace` tree (the
 `project.*` namespace consumed by every template).]]></responsibility>
         <responsibility><![CDATA[Compute derived projections used by templates: flat lists
@@ -412,11 +414,18 @@ doc_id, project_xml)`, `parse_project_to_dict(project_xml)`)
 used by the sidecar so the same code path is used by CLI,
 extension, web form, and AI pipeline.]]></responsibility>
         <responsibility><![CDATA[Provide an `--init` mode that bootstraps a new project's
-`Project.xml` and `PVD.md` from skeletons.]]></responsibility>
+`Project.xml` and hand-authored documents (PVD, SAR, VR, SDP)
+from templates. Prompts before overwriting existing files.]]></responsibility>
+        <responsibility><![CDATA[Provide a `--generate-doc` CLI and `generate_doc()` /
+`generate_all_docs()` library APIs for generating individual
+hand-authored documents from templates under
+`tools/templates/*.template`.]]></responsibility>
         <interfaces title_suffix="(public)">
           <interface title="CLI"><![CDATA[`python3 tools/render_doc.py <template_path>
 <document_id> [--out <path>]` — render one document.
-`python3 tools/render_doc.py --init` — bootstrap.]]></interface>
+`python3 tools/render_doc.py --init` — bootstrap.
+`python3 tools/render_doc.py --generate-doc <id|all>` —
+generate hand-authored document(s) from templates.]]></interface>
           <interface title="Library"><![CDATA[`render_to_str(template_path: Path, document_id: str,
 project_xml: Path) -> str` — render to a string.
 `parse_project_to_dict(project_xml: Path) -> dict` — return
@@ -480,11 +489,13 @@ right Quick Fix.]]></interface>
       </module>
       <module path="tools/templates/">
         <purpose><![CDATA[holds the per-document Jinja2 templates that own all spec-doc
-scaffolding (titles, headings, numbering, tables, anchors).
+scaffolding (titles, headings, numbering, tables, anchors), plus
+hand-authored document templates for project bootstrap.
 
-**Status:** as-built (Phase 1). All five generated documents
-(`SDD`, `HLRs`, `LLRs`, `STP`, `Traceability`) plus the
-`PVD.md.template` bootstrap are present.]]></purpose>
+**Status:** as-built (Phase 1 + Phase 9/12). All five generated
+documents (`SDD`, `HLRs`, `LLRs`, `STP`, `Traceability`) plus
+four bootstrap templates (`PVD.md.template`, `SAR.md.template`,
+`VR.md.template`, `SDP.md.template`) are present.]]></purpose>
         <responsibility><![CDATA[One template per `<metadata><document>` entry. Each consumes
 the `project.*` namespace exposed by `render_doc.py` and
 emits Markdown.]]></responsibility>
@@ -498,8 +509,10 @@ schema, the renderer, and the template to be updated together.]]></responsibilit
 `Traceability.md.j2`. New documents add a sibling template
 plus a `<metadata><document id="…">` entry; from Phase 2.5
 the extension picks them up automatically.]]></interface>
-          <interface title="Bootstrap template"><![CDATA[`PVD.md.template` is consumed by `render_doc.py --init` to
-seed `doc/PVD.md` for new projects.]]></interface>
+          <interface title="Bootstrap template"><![CDATA[`PVD.md.template`, `SAR.md.template`, `VR.md.template`, and
+`SDP.md.template` are consumed by `render_doc.py --init` and
+`render_doc.py --generate-doc` to seed hand-authored documents
+for new projects.]]></interface>
         </interfaces>
         <dependencies>
           <dep><![CDATA[`jinja2`.]]></dep>

--- a/doc/SDP.md
+++ b/doc/SDP.md
@@ -20,10 +20,10 @@
 | [6](#phase-6--polish) | Marketplace polish. | ✅ Done — extension `prepackage` script bundles `tools/{project_io,render_doc,lint_project,project_edit,project_merge}.py`, `project.xsd`, `templates/`, and `ai/` into `tools/vscode-project-xml/dist/python/` and writes the source XSD's `version` attribute into `dist/python/.bundle_version`; `.vscodeignore` retains the bundled tree so the shipped `.vsix` is fully self-contained (HLR-060). `getToolsDir()` falls back to `<extensionPath>/dist/python` when the workspace has no `tools/`. New `Project Spec: Scaffold tools/ into workspace…` command (chained automatically from `Project Spec: Initialise Project.xml…` when the new workspace lacks `tools/`) drops the bundled tree into the workspace, with a single modal collision prompt offering Overwrite all / Skip existing / Cancel (HLR-061). At activation, when the bundled `.bundle_version` is strictly newer than the workspace's `tools/project.xsd` `version`, a one-shot information notification offers a `Re-scaffold tools/` action (HLR-062 — never an error, never blocking). New status-bar item shows `n errors / m warnings` for `doc/Project.xml`; honours `projectXml.warningsAsErrors` (escalates severity, NEVER suppresses; HLR-042); click focuses the Problems panel. Activation events widened to `onCommand:projectXml.{initProject,scaffoldTools}` so the bootstrap and scaffold flows run in an empty workspace. New `.github/workflows/publish-vsix.yml` builds the `.vsix` on `vscode-v*` tag pushes (running `prepackage` before `vsce package`), uploads it as an artifact, and gates `vsce publish` on a `VSCE_PAT` secret (no auto-publish from this commit). |
 | [7](#phase-7---user-documentation-and-additional-polish) | User documentation and additional polish. | ✅ Complete |
 | [8](#phase-8---add-popup-for-editing-leaf-objects) | Popup for editing leaf objects — user does not have to edit XML. | ✅ Complete |
-| [9](#phase-9--create-agents) | Create agents to implement common steps of the daily workflow. | 🔲 Not started |
+| [9](#phase-9--create-agents) | Create agents to implement common steps of the daily workflow. | ✅ Done — agents (`ci`, `makefile`, `TracerDevelop`) and prompts (`PR`, `PrepRelease`, `Release`, `UpdateDocs`) created under `.github/`; document templates (`SAR.md.template`, `VR.md.template`, `SDP.md.template`) and `--generate-doc` CLI added to `render_doc.py`; User Manual and Developers Guide updated with new sections. |
 | [10](#phase-10--refactor-vs-code-extension-providers-humble-object-pattern) | Refactor VS Code extension providers to extract testable logic (humble object pattern). | 🔲 Not started |
 | [11](#phase-11--recordreplay-test-harness-for-ai-authoring-pipeline) | Record/replay test harness for AI authoring pipeline. | 🔲 Not started |
-| [12](#phase-12--create-a-sdp-template) | Create a SDP template (similar to PVD template); update `render_doc` to generate it on init. | 🔲 Not started |
+| [12](#phase-12--create-a-sdp-template) | Create a SDP template (similar to PVD template); update `render_doc` to generate it on init. | ✅ Done — `SDP.md.template`, `SAR.md.template`, and `VR.md.template` created under `tools/templates/`; `render_doc.py` extended with `--generate-doc` CLI and `generate_doc()`/`generate_all_docs()` library APIs; `--init` now generates all four hand-authored documents (PVD, SAR, VR, SDP) with interactive prompts before overwriting existing files. |
 | [TBD](#phase-tbd--address-lint-warnings-and-vulnerabilities) | Address lint warnings and vulnerabilities; security audit report. | 🔲 Not started |
 
 
@@ -557,7 +557,7 @@ payload".
     (`ui:treeNode`, `ui:form`, `ui:lens`, `ui:document`) is
     deferred to Phase 2.5b** — Phase 2.5 only reserves the
     namespace and ships the per-element decoration channel.
-    Developers_Guide.md §14 documents `<plan>` as the example
+    Developers_Guide.md §15 documents `<plan>` as the example
     payload; §15 pins the `Finding` / `LintFinding` / `code`
     contract.
 4.  **Coverage status badges.** Every HLR / LLR leaf in the Project
@@ -627,7 +627,7 @@ lenses, locator, and Phase 3 form panels with no TypeScript edits.
         which ids are renderable targets (today inferred from the
         presence of the `<document>` row itself).
     Document the vocabulary in
-    [Developers_Guide.md](../tools/Developers_Guide.md) alongside §14
+    [Developers_Guide.md](../tools/Developers_Guide.md) alongside §15
     (`<plan>` payload) and §15 (linter contract) shipped in 2.5.
     Bump `<project schema_version>` (1.3 → 1.4).
 2.  **Generic JSON projection.** Replace the hand-typed
@@ -1296,7 +1296,19 @@ Create the following agents and prompts
 
 ### Phase 12 — Create a SDP template
 1.  Create a SDP template similar to the PVD template.
-2.  Update `render_doc` to generate it on `init`.
+2.  Create SAR (Security Audit Report) and VR (Vulnerability Report)
+    templates in the same style.
+3.  Add `--generate-doc` CLI to `render_doc.py` supporting individual
+    document generation (`--generate-doc SAR`) and batch generation
+    (`--generate-doc all`).
+4.  Update `--init` to generate all four hand-authored documents
+    (PVD, SAR, VR, SDP) during project bootstrap, with interactive
+    prompts before overwriting existing files.
+5.  Add `generate_doc()` and `generate_all_docs()` library APIs for
+    programmatic use by the sidecar.
+6.  Acceptance: `python3 tools/render_doc.py --generate-doc all`
+    generates all four documents; `--init` creates them alongside
+    `Project.xml`; existing files prompt before replacement.
 
 ### Phase TBD — Address Lint Warnings and Vulnerabilities
 1.  Address the remaining lint warnings.

--- a/tools/Developers_Guide.md
+++ b/tools/Developers_Guide.md
@@ -10,8 +10,8 @@ This guide is for two audiences:
 2.  **Repository maintainers and contributors** — anyone extending
     the schema, the renderer, the linter, or the VS Code extension.
     [§11 Editing and Authoring Notes](#11-editing-and-authoring-notes),
-    [§15 Linter Contract](#15-linter-contract-finding-findingsitems-code-values),
-    and [§16 UI Hint Vocabulary](#16-ui-hint-vocabulary) cover the
+    [§16 Linter Contract](#16-linter-contract-finding-findingsitems-code-values),
+    and [§17 UI Hint Vocabulary](#17-ui-hint-vocabulary) cover the
     day-to-day contracts; the underlying `Project.xml` schema and
     renderer data surface live in
     [Appendix A: Schema Reference for `Project.xml`](#appendix-a-schema-reference-for-projectxml).
@@ -312,7 +312,60 @@ automatically; you do not need to teach it about the new id.
     visualisations** that go beyond a generic tree node, form, or
     code lens.
 
-## 14. `<plan>` — Phase 2.5 Retrofit Demo Payload
+## 14. Agents and Prompts
+
+TraceR ships reusable VS Code agent and prompt definitions under
+`.github/agents/` and `.github/prompts/`. These are consumed by AI
+coding assistants (such as GitHub Copilot) that support agent and
+prompt discovery.
+
+### Agents
+
+Agent files (`.agent.md`) define interactive assistants that ask
+questions, gather context, and perform tasks. Each has a YAML
+frontmatter header specifying its description, tools, and
+optional sub-agent dependencies.
+
+| File | Scope | Description |
+| ---- | ----- | ----------- |
+| `ci.agent.md` | Generic | GitHub Actions workflow generator. Presents a menu of common workflow categories and generates YAML. |
+| `makefile.agent.md` | Generic | Makefile generator. Prompts for targets and implements them with the `awk`-based self-documenting help hack. |
+| `TracerDevelop.agent.md` | Project-specific | Expert developer agent. Understands the TraceR architecture: Python sidecar, XSD schema, VS Code extension, AI pipeline, and the schema-driven surfaces contract. |
+| `build.agent.md` | Project-specific | Builds the VS Code extension (`npm run build`). |
+| `package.agent.md` | Project-specific | Packages the extension into a `.vsix` (delegates to `build`, then runs `vsce package`). |
+
+### Prompts
+
+Prompt files (`.prompt.md`) define automated multi-step workflows
+with user approval gates. They execute a fixed sequence of
+operations.
+
+| File | Scope | Description |
+| ---- | ----- | ----------- |
+| `UpdateDocs.prompt.md` | Generic | Scans the current branch's changes and updates spec documents (SDD, HLRs, LLRs, Tests in Project.xml; SDP, SAR, User Manual, Developers Guide) to match the implemented work. |
+| `PR.prompt.md` | Generic | Updates the SDP status, generates a release-note-quality commit message, commits, pushes, and opens a pull request. |
+| `PrepRelease.prompt.md` | Generic | Prepares a release branch: bumps VERSION, triages Dependabot alerts, updates the Vulnerability Report, commits, pushes, opens a release PR. |
+| `Release.prompt.md` | Generic | Creates a GitHub Release from the VERSION file with auto-generated categorised release notes. |
+
+### Adding a new agent or prompt
+
+1.  Create a `.agent.md` or `.prompt.md` file under
+    `.github/agents/` or `.github/prompts/`.
+2.  Add a YAML frontmatter header with `description`, `mode`
+    (for prompts), and `tools`.
+3.  Write the body as markdown instructions. Agents should
+    describe their interaction flow and constraints. Prompts
+    should describe numbered steps with approval gates.
+4.  Mark the agent or prompt as **Generic** (works in any TraceR
+    repository) or **Project-specific** (references this
+    project's specific files/architecture).
+
+Generic agents and prompts discover paths dynamically (tools
+directory, test directory, doc directory) and check for the
+existence of optional files (SDP.md, SAR.md, VR.md) before
+attempting to update them.
+
+## 15. `<plan>` — Phase 2.5 Retrofit Demo Payload
 
 The `<plan>` element is the canonical example of a **payload that the
 toolchain learns about purely through `<metadata><document>` and the
@@ -386,7 +439,7 @@ document can either:
     template. The `<plan>` proof remains in the test fixture so
     the schema-driven contract continues to be exercised.
 
-## 15. Linter Contract (`Finding`, `Findings.items[]`, `code` values)
+## 16. Linter Contract (`Finding`, `Findings.items[]`, `code` values)
 
 The linter exposes two complementary surfaces. Earlier phases
 contracted only the human-readable string lists; Phase 2.5 adds a
@@ -403,7 +456,7 @@ Each lint finding is a `Finding` record:
 |------------|-------------------------------------------|-------|
 | `severity` | `"error"` &#124; `"warning"` &#124; `"note"` | Determines how the CLI report and the VS Code Problems panel categorise the entry. |
 | `message`  | `str`                                     | Canonical user-facing text. The CLI report and the legacy `errors` / `warnings` / `notes` lists hold this verbatim — pinned by HLR-043 cross-surface equivalence. |
-| `code`     | `str` &#124; `None`                       | Stable machine identifier. Optional today; populated for the rules listed in §15.3. |
+| `code`     | `str` &#124; `None`                       | Stable machine identifier. Optional today; populated for the rules listed in §16.3. |
 
 `Findings.to_dict()` is the JSON-RPC `lint` method's return shape:
 
@@ -459,7 +512,7 @@ Findings raised before the `code` field was introduced (e.g.
 New rules added in future phases will document their `code` here;
 existing values are stable and may be relied on by external tooling.
 
-## 16. UI Hint Vocabulary
+## 17. UI Hint Vocabulary
 
 [tools/project.xsd](../tools/project.xsd) publishes a small UI-hint
 vocabulary in the namespace `urn:tracer:ui:v1` (prefix `ui:`). The
@@ -559,7 +612,7 @@ standalone tree leaf to decorate.
 
 ### 16.4 Stability
 
-The vocabulary's element and attribute names listed in §16.1 are
+The vocabulary's element and attribute names listed in §17.1 are
 **stable** for any consumer reading the XSD. New `ui:lens` kinds and
 new `ui:field` `kind=` values may be added; existing values will not
 change meaning.
@@ -586,7 +639,7 @@ on the new payload too.
 
 This appendix is the canonical structural reference for
 `doc/Project.xml`: every element, attribute, cardinality, and
-renderer-side projection. The body of this guide (§11–§16) covers
+renderer-side projection. The body of this guide (§11–§17) covers
 authoring rules, the linter contract, and the UI hint vocabulary
 that build on top of the schema. Any change to
 [project.xsd](project.xsd) or [render_doc.py](render_doc.py) MUST be
@@ -627,7 +680,7 @@ breaking existing files. The `urn:tracer:ui:v1` namespace is also
 used by `<xs:appinfo>` blocks inside
 [tools/project.xsd](../tools/project.xsd) to publish a per-element
 UI hint vocabulary (`ui:treeNode`, `ui:form`, `ui:lens`,
-`ui:document`); see [§16. UI Hint Vocabulary](#16-ui-hint-vocabulary).
+`ui:document`); see [§17. UI Hint Vocabulary](#17-ui-hint-vocabulary).
 
 Children may appear in any order; the renderer looks them up by tag.
 The XSD declares `<project>`'s children with `xs:all`, so an
@@ -1172,7 +1225,7 @@ When extending the schema with a new payload root, add a corresponding
 
 Out-of-band of the `project.*` namespace consumed by Jinja templates,
 [tools/render_doc.py](../tools/render_doc.py) also exposes the
-`<xs:appinfo>` UI vocabulary documented in [§16. UI Hint
+`<xs:appinfo>` UI vocabulary documented in [§17. UI Hint
 Vocabulary](#16-ui-hint-vocabulary) as a JSON-serialisable index:
 
 ```python
@@ -1224,7 +1277,7 @@ Templates do **not** consume this index — it is dedicated to
 non-Jinja consumers (the VS Code tree provider, lens provider,
 locator, and Phase 3 form panels). Adding a new `<ui:lens>` `kind=`
 or a new `<ui:field>` `kind=` requires a matching change in the
-consumer (and a §16 update); the index walker itself accepts any
+consumer (and a §17 update); the index walker itself accepts any
 attribute set without further code changes.
 
 ## 10. Regeneration

--- a/tools/User_Manual.md
+++ b/tools/User_Manual.md
@@ -536,11 +536,25 @@ python3 tools/render_doc.py --all
 # Regenerate just one document by name.
 python3 tools/render_doc.py tools/templates/HLRs.md.j2 HLRs --out doc/HLRs.md
 
-# Bootstrap a brand-new project.
+# Bootstrap a brand-new project (creates Project.xml, PVD, SAR, VR, SDP).
 python3 tools/render_doc.py --init \
     --name "MyProject" --short-name MP --author "Me" \
     --xml doc/Project.xml
+
+# Generate a single hand-authored document from its template.
+python3 tools/render_doc.py --generate-doc SAR \
+    --name "MyProject" --short-name MP
+
+# Generate all hand-authored document templates.
+python3 tools/render_doc.py --generate-doc all \
+    --name "MyProject" --short-name MP
 ```
+
+The `--generate-doc` command generates hand-authored documents
+(PVD, SAR, VR, SDP) from templates under `tools/templates/`. If a
+target file already exists, it prompts before overwriting (use
+`--force` to skip the prompt). The `--init` command generates all
+four automatically alongside `Project.xml`.
 
 ### `lint_project.py` — check for problems
 
@@ -626,6 +640,49 @@ already set up.
 That's the loop. For deeper details — the schema, the linter's
 problem codes, how to add a new kind of generated document —
 see the [Developer's Guide](Developers_Guide.md).
+
+## Agents and Prompts
+
+TraceR ships reusable VS Code agent and prompt files under
+`.github/agents/` and `.github/prompts/`. These work with AI
+coding assistants (such as GitHub Copilot) that support agent
+and prompt discovery.
+
+### Agents (`.github/agents/`)
+
+Agents are interactive — they ask questions and guide you
+through a task.
+
+| Agent | Purpose |
+| ----- | ------- |
+| **ci.agent.md** | Create and maintain GitHub Actions workflows. Presents a menu of common workflow categories (CI, code quality, releases, PR automation, etc.) and generates the YAML. |
+| **makefile.agent.md** | Create and maintain Makefiles. Prompts for targets, implements them with the self-documenting help hack (`make help` lists all targets). |
+| **TracerDevelop.agent.md** | Project-specific development agent. Expert in the TraceR architecture (Python tools, VS Code extension, schema, sidecar, AI pipeline). Use for implementing features. |
+| **build.agent.md** | Build the VS Code extension (`npm run build`). |
+| **package.agent.md** | Package the extension into a `.vsix` (delegates to build, then runs `vsce package`). |
+
+### Prompts (`.github/prompts/`)
+
+Prompts are automated workflows — they execute a fixed sequence of
+steps with approval gates.
+
+| Prompt | Purpose |
+| ------ | ------- |
+| **UpdateDocs.prompt.md** | Scan the current branch's changes and update spec documents (SDD, HLRs, LLRs, Tests in Project.xml; SDP, SAR, User Manual, Developers Guide) to match the work done. |
+| **PR.prompt.md** | Update the SDP status, generate a release-note-quality commit message, commit, push, and open a pull request. |
+| **PrepRelease.prompt.md** | Prepare a release: bump VERSION, triage Dependabot alerts (dismiss with justification where possible), update the Vulnerability Report, commit, push, and open a release PR. |
+| **Release.prompt.md** | Create a GitHub Release using the version from VERSION, with auto-generated categorised release notes. |
+
+### Using agents and prompts
+
+In VS Code with GitHub Copilot, agents and prompts appear in the
+Chat panel. Type `@` to see available agents, or use the prompt
+picker to select a prompt. They can also be invoked from the
+command palette.
+
+All prompts are generic — they discover project paths dynamically
+and work in any repository that uses TraceR to maintain a
+`Project.xml`.
 
 ## Appendix A: AI Skill Reference (SKILL.md)
 

--- a/tools/project.xsd
+++ b/tools/project.xsd
@@ -58,7 +58,7 @@
   <!-- `ui:group` attributes via the existing xs:anyAttribute        -->
   <!-- declarations on Hlr / Llr / Test / SddModule (Phase 2.5).     -->
   <!--                                                               -->
-  <!-- See tools/Developers_Guide.md §16 for the full contract.        -->
+  <!-- See tools/Developers_Guide.md §17 for the full contract.        -->
   <!-- ============================================================ -->
 
   <!-- ============================================================ -->

--- a/tools/project_io.py
+++ b/tools/project_io.py
@@ -213,7 +213,7 @@ def _method_ui_hints_index(params: dict[str, Any]) -> dict[str, Any]:
     Used by the VS Code extension's tree provider, lens provider,
     locator, and Phase 3 form panels.
 
-    See tools/Developers_Guide.md §16 for the vocabulary contract and
+    See tools/Developers_Guide.md §17 for the vocabulary contract and
     §9 for the Renderer Data Surface field.
     """
     xsd_path = _as_path(params.get("xsd_path"), PROJECT_XSD)

--- a/tools/render_doc.py
+++ b/tools/render_doc.py
@@ -182,7 +182,7 @@ def parse_ui_hints_index(
     an ``xs:element``) are walked too and keyed under the parent
     element's local name (e.g. ``Plan/item``).
 
-    Pinned by Developers_Guide.md §16 and consumed by
+    Pinned by Developers_Guide.md §17 and consumed by
     [tools/project_io.py](project_io.py)'s ``ui_hints_index`` and
     ``parse_to_json`` JSON-RPC methods (Phase 2.5b).
     """
@@ -922,6 +922,17 @@ def load_project(xml_path: Path, metadata_for: str) -> SimpleNamespace:
 
 
 PVD_TEMPLATE = Path(__file__).resolve().parent / "templates" / "PVD.md.template"
+SAR_TEMPLATE = Path(__file__).resolve().parent / "templates" / "SAR.md.template"
+VR_TEMPLATE = Path(__file__).resolve().parent / "templates" / "VR.md.template"
+SDP_TEMPLATE = Path(__file__).resolve().parent / "templates" / "SDP.md.template"
+
+# All hand-authored document templates (not Jinja2-rendered from Project.xml)
+AUTHORED_TEMPLATES = {
+    "PVD": {"template": PVD_TEMPLATE, "output": "PVD.md"},
+    "SAR": {"template": SAR_TEMPLATE, "output": "SAR.md"},
+    "VR": {"template": VR_TEMPLATE, "output": "VR.md"},
+    "SDP": {"template": SDP_TEMPLATE, "output": "SDP.md"},
+}
 
 
 def _ns_to_jsonable(value: Any) -> Any:
@@ -1187,6 +1198,155 @@ def init_project(
     }
 
 
+def generate_doc(
+    *,
+    doc_id: str,
+    name: str = "<Product Name>",
+    short_name: str = "<short_name>",
+    author: str = "TBD",
+    output_dir: Path | str | None = None,
+    force: bool = False,
+    interactive: bool = False,
+) -> dict[str, Any]:
+    """Generate a hand-authored document from its template.
+
+    ``doc_id`` must be one of the keys in ``AUTHORED_TEMPLATES``
+    (PVD, SAR, VR, SDP).
+
+    When ``interactive=True`` and the target file exists, the caller is
+    expected to have already prompted the user — this function does not
+    perform I/O prompts itself. Use ``_generate_doc_cli`` for the
+    interactive CLI path.
+
+    Returns a result dict with keys:
+      * ``output_path`` — absolute path of the written file
+      * ``skipped``     — True if the file existed and was not overwritten
+    """
+    from datetime import date as _date
+
+    if doc_id not in AUTHORED_TEMPLATES:
+        raise ProjectXmlError(
+            f"Unknown document id '{doc_id}'. "
+            f"Valid ids: {', '.join(sorted(AUTHORED_TEMPLATES))}"
+        )
+
+    entry = AUTHORED_TEMPLATES[doc_id]
+    template_path = Path(entry["template"])
+    if not template_path.exists():
+        raise ProjectXmlError(
+            f"{doc_id} template not found: {template_path}"
+        )
+
+    if output_dir is None:
+        output_dir = Path(__file__).resolve().parent.parent / "doc"
+    output_dir = Path(output_dir)
+    output_path = output_dir / entry["output"]
+
+    if output_path.exists() and not force:
+        return {"output_path": str(output_path), "skipped": True}
+
+    today = _date.today().isoformat()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    text = template_path.read_text()
+    text = text.replace("<Product Name>", name)
+    text = text.replace("<short_name>", short_name)
+    text = text.replace("<YYYY-MM-DD>", today)
+    text = text.replace("<Your name(s)>", author)
+    output_path.write_text(text)
+
+    return {"output_path": str(output_path), "skipped": False}
+
+
+def generate_all_docs(
+    *,
+    name: str = "<Product Name>",
+    short_name: str = "<short_name>",
+    author: str = "TBD",
+    output_dir: Path | str | None = None,
+    force: bool = False,
+) -> list[dict[str, Any]]:
+    """Generate all hand-authored document templates.
+
+    Returns a list of result dicts (one per document) from generate_doc.
+    """
+    results = []
+    for doc_id in AUTHORED_TEMPLATES:
+        result = generate_doc(
+            doc_id=doc_id,
+            name=name,
+            short_name=short_name,
+            author=author,
+            output_dir=output_dir,
+            force=force,
+        )
+        results.append({"doc_id": doc_id, **result})
+    return results
+
+
+def _generate_doc_cli(
+    *,
+    doc_ids: list[str],
+    name: str,
+    short_name: str,
+    author: str,
+    output_dir: Path,
+    force: bool,
+) -> int:
+    """CLI wrapper for generate_doc: prompts on existing files."""
+    from datetime import date as _date
+
+    had_error = False
+    for doc_id in doc_ids:
+        if doc_id not in AUTHORED_TEMPLATES:
+            sys.stderr.write(
+                f"render_doc.py --generate-doc: unknown document id "
+                f"'{doc_id}'. Valid ids: "
+                f"{', '.join(sorted(AUTHORED_TEMPLATES))}\n"
+            )
+            had_error = True
+            continue
+
+        entry = AUTHORED_TEMPLATES[doc_id]
+        output_path = output_dir / entry["output"]
+
+        do_write = force
+        if output_path.exists() and not force:
+            # Interactive prompt
+            try:
+                answer = input(
+                    f"{output_path} already exists. Replace? [y/N] "
+                )
+            except (EOFError, KeyboardInterrupt):
+                sys.stderr.write("\nAborted.\n")
+                return 1
+            do_write = answer.strip().lower() in ("y", "yes")
+            if not do_write:
+                sys.stderr.write(f"  Skipped {output_path}\n")
+                continue
+
+        try:
+            result = generate_doc(
+                doc_id=doc_id,
+                name=name,
+                short_name=short_name,
+                author=author,
+                output_dir=output_dir,
+                force=True,  # We already prompted
+            )
+        except ProjectXmlError as exc:
+            sys.stderr.write(f"render_doc.py --generate-doc: {exc}\n")
+            had_error = True
+            continue
+
+        if result["skipped"]:
+            sys.stderr.write(f"  Skipped {result['output_path']}\n")
+        else:
+            sys.stderr.write(f"  Wrote {result['output_path']}\n")
+
+    return 1 if had_error else 0
+
+
 def _init_project_cli(
     *,
     name: str,
@@ -1236,6 +1396,38 @@ def _init_project_cli(
 
     sys.stderr.write(f"Wrote skeleton {result['xml_path']}\n")
     sys.stderr.write(f"Wrote {result['pvd_path']}\n")
+
+    # Generate the other hand-authored templates (SAR, VR, SDP)
+    output_dir = pvd_path.parent
+    for doc_id in ("SAR", "VR", "SDP"):
+        entry = AUTHORED_TEMPLATES[doc_id]
+        output_path = output_dir / entry["output"]
+        do_write = force
+        if output_path.exists() and not force:
+            try:
+                answer = input(
+                    f"{output_path} already exists. Replace? [y/N] "
+                )
+            except (EOFError, KeyboardInterrupt):
+                sys.stderr.write(f"\n  Skipped {output_path}\n")
+                continue
+            do_write = answer.strip().lower() in ("y", "yes")
+        if not do_write and output_path.exists():
+            sys.stderr.write(f"  Skipped {output_path}\n")
+            continue
+        try:
+            doc_result = generate_doc(
+                doc_id=doc_id,
+                name=name,
+                short_name=short_name,
+                author=author,
+                output_dir=output_dir,
+                force=True,
+            )
+            sys.stderr.write(f"Wrote {doc_result['output_path']}\n")
+        except ProjectXmlError as exc:
+            sys.stderr.write(f"  Warning: {exc}\n")
+
     sys.stderr.write(
         "Next steps: edit doc/PVD.md, then populate doc/Project.xml "
         "and regenerate the spec documents with render_doc.py.\n"
@@ -1273,11 +1465,19 @@ def main() -> int:
         ),
         epilog=(
             "EXAMPLES\n"
-            "  Bootstrap a new project (writes doc/Project.xml and\n"
-            "  doc/PVD.md from the skeletons):\n"
+            "  Bootstrap a new project (writes doc/Project.xml, PVD.md,\n"
+            "  SAR.md, VR.md, SDP.md from skeletons):\n"
             "    python3 tools/render_doc.py --init \\\n"
             "        --name \"My Product\" --short-name myprod \\\n"
             "        --author \"Jane Doe\"\n"
+            "\n"
+            "  Generate a single hand-authored document:\n"
+            "    python3 tools/render_doc.py --generate-doc SAR \\\n"
+            "        --name \"My Product\" --short-name myprod\n"
+            "\n"
+            "  Generate all hand-authored documents:\n"
+            "    python3 tools/render_doc.py --generate-doc all \\\n"
+            "        --name \"My Product\" --short-name myprod\n"
             "\n"
             "  Render the SDD to stdout:\n"
             "    python3 tools/render_doc.py tools/templates/SDD.md.j2 SDD\n"
@@ -1353,17 +1553,19 @@ def main() -> int:
     )
     init_group = parser.add_argument_group(
         "project bootstrap (--init)",
-        "Create a skeleton Project.xml plus a substituted PVD.md as the "
-        "first step of a new project. When --init is given, TEMPLATE and "
-        "METADATA_ID are not required.",
+        "Create a skeleton Project.xml plus hand-authored document "
+        "templates (PVD, SAR, VR, SDP) as the first step of a new "
+        "project. When --init is given, TEMPLATE and METADATA_ID are "
+        "not required.",
     )
     init_group.add_argument(
         "--init",
         action="store_true",
         help=(
             "Create a skeleton Project.xml at --xml (default doc/Project.xml) "
-            "and a substituted PVD.md at --pvd-out (default doc/PVD.md). "
-            "Refuses to overwrite existing files unless --force is also given."
+            "and hand-authored documents (PVD, SAR, VR, SDP) under the "
+            "output directory. Prompts before overwriting existing files "
+            "unless --force is also given."
         ),
     )
     init_group.add_argument(
@@ -1401,7 +1603,10 @@ def main() -> int:
     init_group.add_argument(
         "--force",
         action="store_true",
-        help="With --init, overwrite existing Project.xml / PVD.md.",
+        help=(
+            "With --init or --generate-doc, overwrite existing files "
+            "without prompting."
+        ),
     )
     init_group.add_argument(
         "--schema-location",
@@ -1415,7 +1620,48 @@ def main() -> int:
             "computed automatically."
         ),
     )
+    gen_group = parser.add_argument_group(
+        "document generation (--generate-doc)",
+        "Generate hand-authored document(s) from their templates. "
+        "Prompts before overwriting existing files unless --force is given. "
+        "Valid document ids: " + ", ".join(sorted(AUTHORED_TEMPLATES)) + ".",
+    )
+    gen_group.add_argument(
+        "--generate-doc",
+        nargs="+",
+        metavar="DOC_ID",
+        help=(
+            "Generate one or more hand-authored documents from templates. "
+            "Use 'all' to generate all available templates. "
+            "Valid ids: " + ", ".join(sorted(AUTHORED_TEMPLATES)) + "."
+        ),
+    )
+    gen_group.add_argument(
+        "--doc-out-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent / "doc",
+        metavar="PATH",
+        help="Output directory for generated documents. Default: %(default)s.",
+    )
     args = parser.parse_args()
+
+    if args.generate_doc:
+        doc_ids = []
+        for d in args.generate_doc:
+            if d.lower() == "all":
+                doc_ids = list(AUTHORED_TEMPLATES.keys())
+                break
+            doc_ids.append(d.upper() if d.upper() in AUTHORED_TEMPLATES else d)
+        name = args.name or "<Product Name>"
+        short_name = args.short_name or "<short_name>"
+        return _generate_doc_cli(
+            doc_ids=doc_ids,
+            name=name,
+            short_name=short_name,
+            author=args.author,
+            output_dir=args.doc_out_dir,
+            force=args.force,
+        )
 
     if args.init:
         if not args.name or not args.short_name:

--- a/tools/templates/SAR.md.template
+++ b/tools/templates/SAR.md.template
@@ -1,0 +1,171 @@
+# Security Audit Report: <Product Name> (<short_name>)
+
+**Version:** 0.1
+**Date:** <YYYY-MM-DD>
+**Author(s):** <Your name(s)>
+
+> **How to use this template.** Each section below contains the
+> *intent* of the section followed by **prompts** to elicit the
+> content. Replace every `<placeholder>` and the prompt block with
+> your own prose. Delete prompts once a section is filled in.
+
+## 1. Purpose
+
+This Security Audit Report (SAR) documents the security posture of
+`<short_name>`, including the methodology used, findings from static
+and dynamic analysis, and recommendations for remediation.
+
+This document is a point-in-time assessment. For the living list of
+known vulnerabilities and their status, see the companion
+[Vulnerability Report](VR.md).
+
+> *No prompts — this section is boilerplate. Just substitute the
+> product name above.*
+
+## 2. Scope & Methodology
+
+> **Prompts**
+> *   What components were assessed? (source code, dependencies,
+>     infrastructure, deployment configuration, etc.)
+> *   What tools and techniques were used? (SAST, DAST, manual
+>     code review, threat modelling, penetration testing, etc.)
+> *   What was explicitly excluded from the audit?
+> *   What version / commit was audited?
+
+| Aspect | Detail |
+| ------ | ------ |
+| **Components in scope** | <List: source code, dependencies, configs, etc.> |
+| **Tools used** | <List: CodeQL, Semgrep, Bandit, npm audit, etc.> |
+| **Manual review** | <Yes/No — describe focus areas if yes> |
+| **Commit / version** | <Git SHA or release tag> |
+| **Date of audit** | <YYYY-MM-DD> |
+| **Exclusions** | <What was not audited and why> |
+
+## 3. Security Architecture Overview
+
+> **Prompts**
+> *   What are the trust boundaries in the system?
+> *   Where does untrusted input enter?
+> *   What authentication / authorisation mechanisms exist?
+> *   How are secrets managed?
+> *   What are the data flows between components?
+
+<Describe or diagram the security-relevant architecture here.>
+
+## 4. Integration with the Traceability Stack
+
+Security requirements in this project are tracked through the same
+traceability mechanism as all other requirements:
+
+1. **Security concerns** are documented as components or constraints
+   in the [Software Design Document](SDD.md).
+2. **Security requirements** are captured as High-Level Requirements
+   (HLRs) in [Project.xml](Project.xml) — typically prefixed
+   `HLR-SEC-*` — and traced to the SDD component they implement.
+3. **Implementation details** are captured as Low-Level Requirements
+   (LLRs) traced to their parent HLR(s).
+4. **Verification** is captured as test cases in the
+   [Software Test Plan](STP.md), traced to the LLR(s) they verify.
+5. **Coverage** is visible in the
+   [Traceability Matrix](Traceability.md) — gaps in security
+   test coverage appear as lint warnings alongside all other
+   coverage gaps.
+
+This audit report is an *assessment artefact* — it validates that
+the above process is being followed and identifies gaps. It is not
+itself integrated into the traceability matrix.
+
+## 5. OWASP Top 10 / CWE Analysis
+
+> **Prompts**
+> *   For each applicable OWASP Top 10 category, state whether the
+>     product is exposed, mitigated, or not applicable, with brief
+>     justification.
+
+| # | OWASP Category | Applicability | Status | Notes |
+|---|----------------|---------------|--------|-------|
+| A01 | Broken Access Control | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A02 | Cryptographic Failures | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A03 | Injection | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A04 | Insecure Design | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A05 | Security Misconfiguration | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A06 | Vulnerable/Outdated Components | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A07 | Identification/Authentication Failures | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A08 | Software/Data Integrity Failures | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A09 | Security Logging/Monitoring Failures | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+| A10 | Server-Side Request Forgery | <Applicable/N/A> | <Mitigated/Open/N/A> | <Brief notes> |
+
+## 6. Static Analysis Findings
+
+> **Prompts**
+> *   What did SAST tools report?
+> *   Categorise findings by severity (Critical / High / Medium / Low / Info).
+> *   For each finding, state: tool, rule, location, and disposition
+>     (fixed, accepted risk, false positive).
+
+| Severity | Tool | Rule/CWE | Location | Disposition | Notes |
+|----------|------|----------|----------|-------------|-------|
+| <Critical/High/Medium/Low> | <Tool> | <Rule ID> | <file:line> | <Fixed/Accepted/FP> | <Brief> |
+
+## 7. Dependency Security
+
+> **Prompts**
+> *   What dependency scanning was performed?
+> *   Summarise the findings at a high level (counts by severity).
+> *   Individual CVEs and their status belong in the
+>     [Vulnerability Report](VR.md) — reference it here.
+
+| Ecosystem | Scanner | Critical | High | Medium | Low |
+|-----------|---------|----------|------|--------|-----|
+| Python (pip) | <Tool> | <n> | <n> | <n> | <n> |
+| Node.js (npm) | <Tool> | <n> | <n> | <n> | <n> |
+
+For individual CVE details and disposition, see [VR.md](VR.md).
+
+## 8. Input Validation & Injection Surfaces
+
+> **Prompts**
+> *   Where does untrusted data enter the system?
+> *   What validation is applied at each entry point?
+> *   Are there any gaps?
+
+| Entry Point | Input Source | Validation | Notes |
+|-------------|-------------|------------|-------|
+| <Component/endpoint> | <User/file/network/etc.> | <Schema/sanitise/none> | <Adequate/Gap> |
+
+## 9. Secrets & Credential Hygiene
+
+> **Prompts**
+> *   Are there any hardcoded secrets in the repository?
+> *   How are tokens, API keys, and credentials managed?
+> *   Are secrets rotated? How?
+
+<Describe findings here.>
+
+## 10. Recommendations
+
+> **Prompts**
+> *   Prioritise remediation actions (Critical → Low).
+> *   For each recommendation, name the affected component and
+>     the expected outcome.
+
+| Priority | Recommendation | Component | Expected Outcome |
+|----------|---------------|-----------|-----------------|
+| <Critical/High/Medium/Low> | <Action> | <Component> | <What improves> |
+
+## 11. Residual Risk Summary
+
+> **Prompts**
+> *   After all mitigations, what risk remains?
+> *   What assumptions underpin the current security posture?
+> *   Under what conditions should this audit be repeated?
+
+<Summarise the residual risk and the conditions that would trigger
+a re-audit.>
+
+## 12. Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Author | <Name> | <Date> | |
+| Reviewer | <Name> | <Date> | |

--- a/tools/templates/SDP.md.template
+++ b/tools/templates/SDP.md.template
@@ -1,0 +1,202 @@
+# Software Development Plan: <Product Name> (<short_name>)
+
+**Version:** 0.1
+**Date:** <YYYY-MM-DD>
+**Author(s):** <Your name(s)>
+
+> **How to use this template.** Each section below contains the
+> *intent* of the section followed by **prompts** to elicit the
+> content. Replace every `<placeholder>` and the prompt block with
+> your own prose. Delete prompts once a section is filled in.
+>
+> The SDP is a living document — update the Status table and Phased
+> Delivery section as work progresses. Link phase names in the Status
+> table to their detailed descriptions in §8.
+
+**Status:** <Overall project status summary>
+
+## Status
+
+> **Prompts**
+> *   Create a row for each phase of your project.
+> *   Link the phase number/name to its detailed description in §8.
+> *   Use status indicators: ✅ Complete, 🔲 Not started,
+>     🔄 In progress.
+
+| Phase | Description | Status |
+| ----- | ----------- | ------ |
+| [0](#phase-0--placeholder) | <Brief description> | 🔲 Not started |
+| [1](#phase-1--placeholder) | <Brief description> | 🔲 Not started |
+
+## 0. Required Tools for Development
+
+> **Prompts**
+> *   What tools, languages, and runtimes must a developer have
+>     installed to build, test, and run this project?
+> *   Include version constraints where they matter.
+> *   List both required and optional (nice-to-have) tools.
+
+### Required
+
+| Tool | Version | Purpose |
+| ---- | ------- | ------- |
+| <Language/Runtime> | <≥ X.Y> | <What it's used for> |
+| <Package manager> | <≥ X.Y> | <What it's used for> |
+| <Build tool> | <≥ X.Y> | <What it's used for> |
+
+### Optional
+
+| Tool | Purpose |
+| ---- | ------- |
+| <Tool> | <What it enables> |
+
+## 1. Motivation
+
+> **Prompts**
+> *   Why does this project exist? What problem does it solve?
+> *   Why this approach over alternatives?
+> *   Link to the [PVD](PVD.md) for the full vision — this section
+>     is the SDP-local summary.
+
+<Brief motivation linking to the PVD.>
+
+## 2. Goals
+
+> **Prompts**
+> *   What must the delivered product do? List the goals as a
+>     numbered or bulleted list.
+> *   Each goal should be verifiable — you can tell when it's done.
+> *   Cross-reference the PVD value proposition where applicable.
+
+1. <Goal 1.>
+2. <Goal 2.>
+3. <Goal 3.>
+
+## 3. Non-Goals
+
+> **Prompts**
+> *   What is explicitly not in scope for this plan?
+> *   These prevent scope creep and set expectations.
+
+*   <Non-goal 1.>
+*   <Non-goal 2.>
+
+## 4. Design — see the SDD
+
+> **Prompts**
+> *   If architecture details live in a separate SDD, reference it
+>     here. Otherwise, provide a high-level architecture overview.
+
+The detailed software architecture is documented in the
+[Software Design Document](SDD.md). Key components:
+
+*   <Component 1> — <one-line purpose>
+*   <Component 2> — <one-line purpose>
+
+## 5. Development Process
+
+> **Prompts**
+> *   What branching strategy is used? (trunk-based, Git Flow, etc.)
+> *   How are changes reviewed and merged?
+> *   What CI checks must pass?
+> *   What is the release process?
+
+### 5.1 Branching Strategy
+
+<Describe your branching model.>
+
+### 5.2 Code Review
+
+<Describe your review process.>
+
+### 5.3 Continuous Integration
+
+<Describe CI checks and gates.>
+
+### 5.4 Release Process
+
+<Describe how releases are cut and published.>
+
+## 6. Testing Strategy
+
+> **Prompts**
+> *   What kinds of tests exist? (unit, integration, e2e, manual)
+> *   What coverage targets are expected?
+> *   How do tests relate to the LLRs and STP?
+
+| Level | Scope | Tools | Coverage Target |
+| ----- | ----- | ----- | --------------- |
+| Unit | <Scope> | <pytest/mocha/etc.> | <Target %> |
+| Integration | <Scope> | <Tools> | <Target %> |
+
+Tests are traced to Low-Level Requirements in [Project.xml](Project.xml)
+and reported in the [Software Test Plan](STP.md) and
+[Traceability Matrix](Traceability.md).
+
+## 7. Dependencies & Prerequisites
+
+> **Prompts**
+> *   What external dependencies does the project rely on?
+> *   Are there ordering constraints between phases?
+> *   What must be true before Phase 1 can start?
+
+| Dependency | Required By | Notes |
+| ---------- | ----------- | ----- |
+| <Dependency 1> | Phase <N> | <Notes> |
+
+## 8. Phased Delivery
+
+> **Prompts**
+> *   Break the work into numbered phases, each with:
+>     - A descriptive title
+>     - A numbered list of deliverables
+>     - Acceptance criteria (how you know the phase is done)
+>     - Optionally, an AI prompt that could drive the implementation
+> *   Phases should be deliverable independently where possible.
+> *   Earlier phases should produce value on their own.
+
+### Phase 0 — <Title>
+
+1. <Deliverable 1.>
+2. <Deliverable 2.>
+
+**Acceptance:** <How you know this phase is complete.>
+
+### Phase 1 — <Title>
+
+1. <Deliverable 1.>
+2. <Deliverable 2.>
+
+**Acceptance:** <How you know this phase is complete.>
+
+## 9. Risks & Open Questions
+
+> **Prompts**
+> *   What could go wrong? What is uncertain?
+> *   For each risk, name the impact and any mitigation.
+> *   Open questions are things you need to decide but haven't yet.
+
+*   **<Risk 1>.** <Impact and mitigation.>
+*   **<Risk 2>.** <Impact and mitigation.>
+
+## 10. Estimated Effort
+
+> **Prompts**
+> *   Optionally provide effort estimates per phase.
+> *   Use ranges or t-shirt sizes if precise estimates aren't
+>     available.
+> *   This section may be omitted if not useful.
+
+| Phase | Effort |
+| ----- | ------ |
+| 0 | <Estimate> |
+| 1 | <Estimate> |
+
+## 11. Out-of-Scope Follow-ups
+
+> **Prompts**
+> *   Ideas that surfaced during planning but are not committed.
+> *   These may become future phases if demand warrants.
+
+*   <Follow-up 1.>
+*   <Follow-up 2.>

--- a/tools/templates/VR.md.template
+++ b/tools/templates/VR.md.template
@@ -1,0 +1,134 @@
+# Vulnerability Report: <Product Name> (<short_name>)
+
+**Version:** 0.1
+**Date:** <YYYY-MM-DD>
+**Author(s):** <Your name(s)>
+
+> **How to use this template.** This is a living document — update it
+> as vulnerabilities are discovered, mitigated, or accepted. Each
+> entry should be kept current with its latest status. Replace every
+> `<placeholder>` and the prompt blocks with your own content. Delete
+> prompts once a section is filled in.
+
+## 1. Purpose
+
+This Vulnerability Report (VR) tracks all known security
+vulnerabilities in `<short_name>` and its dependencies. It serves
+as the canonical inventory of:
+
+- Vulnerabilities discovered by automated scanners (Dependabot,
+  npm audit, pip-audit, CodeQL, etc.)
+- Vulnerabilities identified during manual review or penetration
+  testing
+- The disposition of each (fixed, mitigated, accepted, dismissed)
+
+For the broader security assessment, see the companion
+[Security Audit Report](SAR.md).
+
+> *No prompts — this section is boilerplate. Just substitute the
+> product name above.*
+
+## 2. Summary
+
+> **Prompts**
+> *   How many open vulnerabilities exist by severity?
+> *   What is the overall trend (improving, stable, degrading)?
+
+| Severity | Open | Mitigated | Accepted | Dismissed | Fixed |
+|----------|------|-----------|----------|-----------|-------|
+| Critical | <n> | <n> | <n> | <n> | <n> |
+| High | <n> | <n> | <n> | <n> | <n> |
+| Medium | <n> | <n> | <n> | <n> | <n> |
+| Low | <n> | <n> | <n> | <n> | <n> |
+
+**Last updated:** <YYYY-MM-DD>
+
+## 3. Scanning Configuration
+
+> **Prompts**
+> *   What automated scanners are configured?
+> *   How frequently do they run?
+> *   Where do alerts surface (GitHub Security tab, CI logs, etc.)?
+
+| Scanner | Ecosystem | Frequency | Alert Destination |
+|---------|-----------|-----------|-------------------|
+| <Dependabot> | <npm/pip/etc.> | <Daily/Weekly/On PR> | <GitHub Security tab> |
+| <npm audit> | <npm> | <CI on every PR> | <CI logs> |
+| <pip-audit> | <Python> | <CI on every PR> | <CI logs> |
+
+## 4. Open Vulnerabilities
+
+> **Prompts**
+> *   List each open vulnerability with its CVE (if assigned),
+>     severity, affected component, and planned action.
+> *   Keep entries sorted by severity (Critical first).
+
+### 4.1 Critical
+
+| CVE / ID | Component | Version | Description | Planned Action | Target Date |
+|----------|-----------|---------|-------------|----------------|-------------|
+| <CVE-YYYY-NNNNN> | <package> | <version> | <Brief description> | <Upgrade/Patch/Mitigate> | <YYYY-MM-DD> |
+
+### 4.2 High
+
+| CVE / ID | Component | Version | Description | Planned Action | Target Date |
+|----------|-----------|---------|-------------|----------------|-------------|
+| — | — | — | No open high-severity vulnerabilities. | — | — |
+
+### 4.3 Medium
+
+| CVE / ID | Component | Version | Description | Planned Action | Target Date |
+|----------|-----------|---------|-------------|----------------|-------------|
+| — | — | — | No open medium-severity vulnerabilities. | — | — |
+
+### 4.4 Low
+
+| CVE / ID | Component | Version | Description | Planned Action | Target Date |
+|----------|-----------|---------|-------------|----------------|-------------|
+| — | — | — | No open low-severity vulnerabilities. | — | — |
+
+## 5. Accepted Risks
+
+> **Prompts**
+> *   List vulnerabilities that have been assessed and deliberately
+>     accepted (not fixed), along with the justification.
+> *   Each acceptance should name who approved it and under what
+>     conditions it should be re-evaluated.
+
+| CVE / ID | Component | Severity | Justification | Approved By | Re-evaluate |
+|----------|-----------|----------|---------------|-------------|-------------|
+| <CVE-YYYY-NNNNN> | <package> | <Severity> | <Why this is acceptable in context> | <Name> | <Condition or date> |
+
+## 6. Dismissed Vulnerabilities
+
+> **Prompts**
+> *   List vulnerabilities dismissed as false positives or not
+>     applicable, with justification.
+
+| CVE / ID | Component | Severity | Reason for Dismissal |
+|----------|-----------|----------|---------------------|
+| <CVE-YYYY-NNNNN> | <package> | <Severity> | <Not applicable because…> |
+
+## 7. Resolved Vulnerabilities (History)
+
+> **Prompts**
+> *   Keep a log of vulnerabilities that have been fixed, for
+>     audit trail purposes. Move entries here from §4 when resolved.
+
+| CVE / ID | Component | Severity | Resolution | Date Fixed |
+|----------|-----------|----------|-----------|------------|
+| <CVE-YYYY-NNNNN> | <package> | <Severity> | <Upgraded to version X.Y.Z> | <YYYY-MM-DD> |
+
+## 8. Process
+
+> **Prompts**
+> *   How are new vulnerabilities triaged?
+> *   What is the SLA for each severity level?
+> *   Who is responsible for remediation?
+
+| Severity | Response SLA | Remediation SLA | Owner |
+|----------|-------------|-----------------|-------|
+| Critical | <24 hours> | <7 days> | <Role/Name> |
+| High | <48 hours> | <30 days> | <Role/Name> |
+| Medium | <1 week> | <90 days> | <Role/Name> |
+| Low | <2 weeks> | <Next release> | <Role/Name> |

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -479,7 +479,7 @@ export interface InitProjectResult {
  * locator, and Phase 3 form panels) read this index instead of
  * special-casing per-payload element names.
  *
- * See tools/Developers_Guide.md §16 for the contract.
+ * See tools/Developers_Guide.md §17 for the contract.
  */
 export interface UiTreeNode {
     label: string;


### PR DESCRIPTION
## Summary

- Add 3 VS Code agents: `ci.agent.md` (CI workflow generator), `makefile.agent.md` (Makefile creator), `TracerDevelop.agent.md` (project-specific development expert)
- Add 4 VS Code prompts: `PR.prompt.md` (commit/push/PR workflow), `PrepRelease.prompt.md` (release preparation), `Release.prompt.md` (GitHub Release creation), `UpdateDocs.prompt.md` (spec document updater)
- Add 3 document templates: `SAR.md.template`, `VR.md.template`, `SDP.md.template`
- Extend `render_doc.py` with `--generate-doc` CLI and `generate_doc()` / `generate_all_docs()` library APIs; `--init` now bootstraps all four hand-authored documents (PVD, SAR, VR, SDP)
- Update `User_Manual.md` with `--generate-doc` usage and new Agents & Prompts section
- Insert `Developers_Guide.md` §14 (Agents and Prompts); renumber §14–§16 → §15–§17 and fix cross-references across 6 files
- Update SDD modules in `Project.xml` for `render_doc.py` and `templates/`
- Mark SDP Phase 9 ✅ Done and Phase 12 ✅ Done

## Checklist

- [x] SDP updated (Phase 9 → ✅ Done, Phase 12 → ✅ Done)
- [x] SDD updated in Project.xml
- [x] User Manual updated
- [x] Developers Guide updated
- [x] Cross-references fixed across 6 files
- [x] Tests pass (155/155)
- [x] Lint clean (0 errors)

Closes #29