### PR TITLE
feat(extension): complete SDD module and STP fixture editing in tree and forms

### DIFF
--- a/doc/Project.xml
+++ b/doc/Project.xml
@@ -910,7 +910,7 @@ gaps or broken refs.]]></responsibility>
 commands per node is derived from the hint registry, not
 hard-coded per element kind.]]></responsibility>
         <responsibility><![CDATA[Set `TreeItem.command` on every leaf node (individual
-`<hlr>`, `<llr>`, `<test>`, `<module>`) to
+`<hlr>`, `<llr>`, `<test>`, `<module>`, `<fixture>`) to
 `projectXml.editPayload`, so that double-clicking a leaf
 in the tree opens the schema-driven popup edit dialog for
 that element. The dialog is a single reusable popup whose
@@ -918,6 +918,11 @@ fields are derived at runtime from the element's XSD
 complex type and `ui:form` hints — no per-payload code
 and no extension changes when a user adds a new document
 or payload kind.]]></responsibility>
+        <responsibility><![CDATA[Render the STP tree group as a collapsible node
+whose children are the `<fixture>` elements under
+`<stp>/<integration_environment>`, each carrying
+`editArgs` so the edit form opens on double-click and
+the context menu exposes `addStpFixture`.]]></responsibility>
         <responsibility><![CDATA[Locate elements in the underlying XML for `Reveal in XML`
 via the generic locator (`util/locator.ts`), which takes
 `(elementName, idAttr, idValue)` from the hint registry.]]></responsibility>
@@ -2809,6 +2814,13 @@ and `diffPreviewLogic.ts`.]]></text>
           <trace target="HLR" ref="HLR-022" name="Project Spec Tree View"/>
         </traces>
       </llr>
+      <llr id="LLR-PSP-10">
+        <text><![CDATA[`buildStpDescriptor` shall render the STP tree group as a collapsible node labelled `STP (N fixtures)` whose children are one leaf per `<fixture>` element under `<stp>/<integration_environment>`. Each fixture leaf shall carry an `editArgs` with `type='StpFixture'`, `basePath='/stp/integration_environment/fixture[name=X]'`, and `formData` containing `name` and `source` fields, and shall set `contextValue` to `stpGroup` on the parent so the context menu exposes the `addStpFixture` command. When no STP section exists the node shall render as `STP (empty)` with no children and no context value.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-022" name="Project Spec Tree View"/>
+          <trace target="HLR" ref="HLR-026" name="Structured Form Editing"/>
+        </traces>
+      </llr>
     </function>
     <function number="12" title="`LintDiagnosticsProvider` ([tools/vscode-project-xml/src/diagnostics/LintDiagnosticsProvider.ts](../tools/vscode-project-xml/src/diagnostics/LintDiagnosticsProvider.ts))" name="LintDiagnosticsProvider" source="tools/vscode-project-xml/src/diagnostics/LintDiagnosticsProvider.ts">
       <intro><![CDATA[Mirrors lint findings from `project_io.lint` into a VS Code `DiagnosticCollection` over `Project.xml`. Phase 2.5's stable-`code` retrofit and Quick Fix table layer on top of this Phase 1 surface.]]></intro>
@@ -3234,10 +3246,17 @@ and `diffPreviewLogic.ts`.]]></text>
         </traces>
       </llr>
       <llr id="LLR-FRM-11">
-        <text><![CDATA[`resolveFormParams(parsed, locator)` shall walk the nested project structure (`hlrs`, `llrs`, `tests`, `sdd`) to resolve a `{tag, value}` coverage locator into an `OpenFormParams` object containing the `type`, `basePath`, and pre-populated `initial` data. Supported tags are `hlr`, `llr`, `test`, and `module`; unrecognised tags or missing items shall return `undefined`. The extension host's `openForm` message handler shall call `resolveFormParams` and open a new form panel for the resolved item so coverage-hint clicks navigate directly to the target's edit form.]]></text>
+        <text><![CDATA[`resolveFormParams(parsed, locator)` shall walk the nested project structure (`hlrs`, `llrs`, `tests`, `sdd`, `stp`) to resolve a `{tag, value}` coverage locator into an `OpenFormParams` object containing the `type`, `basePath`, and pre-populated `initial` data. Supported tags are `hlr`, `llr`, `test`, `module`, and `fixture`; unrecognised tags or missing items shall return `undefined`. The extension host's `openForm` message handler shall call `resolveFormParams` and open a new form panel for the resolved item so coverage-hint clicks navigate directly to the target's edit form.]]></text>
         <traces>
           <trace target="HLR" ref="HLR-026" name="Structured Form Editing"/>
           <trace target="HLR" ref="HLR-063" name="Tree View Coverage Tooltips"/>
+        </traces>
+      </llr>
+      <llr id="LLR-FRM-14">
+        <text><![CDATA[When the SDD module edit form opens (via `editPayload` or `resolveFormParams`), the `formData` / `initial` object passed to the webview shall include all child element fields declared in the XSD `<ui:form>` annotation (`purpose`, `responsibility`, `data_structures`, `algorithm`) in addition to the attribute fields (`path`, `title`). Multi-valued children (e.g. multiple `<responsibility>` elements) shall be joined with newline separators into a single string so the textarea widget displays them as a block.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-026" name="Structured Form Editing"/>
+          <trace target="HLR" ref="HLR-022" name="Project Spec Tree View"/>
         </traces>
       </llr>
       <llr id="LLR-FRM-12">
@@ -4878,7 +4897,7 @@ and shall not block the resolution flow.]]></text>
         </traces>
       </test>
     </file>
-    <file path="tools/vscode-project-xml/test/unit/formPanel.test.ts" role="unit-ts" count="25">
+    <file path="tools/vscode-project-xml/test/unit/formPanel.test.ts" role="unit-ts" count="28">
       <header><![CDATA[Phase 3 tests for the pure `buildOperations` helper exported from FormPanelProvider, the `computeCoverage` inline summary, `resolveFormParams` coverage-link navigation, plus `package.json` contribution-point assertions. Pins the JSON Patch shape the form panel posts to the sidecar without needing the VS Code webview API.]]></header>
       <test name="emits a single add op with @attr keys when in add mode">
         <purpose><![CDATA[Pins LLR-FRM-03: in add mode the helper emits exactly one `add` op whose value uses the `@attr` / bare-key convention apply_edit understands.]]></purpose>
@@ -4942,6 +4961,20 @@ and shall not block the resolution flow.]]></text>
         <purpose><![CDATA[Pins LLR-FRM-06: callers that omit the `fields` argument retain the Phase 3 `id`/`name`-as-attribute behaviour so existing HLR/LLR call sites keep working unchanged.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-FRM-06"/>
+        </traces>
+      </test>
+      <test name="emits replace ops for SddModule attrs and child fields in edit mode">
+        <purpose><![CDATA[Pins LLR-FRM-06 + LLR-FRM-14: in edit mode, buildOperations emits one replace op per attribute (@path, @title) and one per child element body (purpose, responsibility, data_structures, algorithm) when the fields array classifies them correctly.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-FRM-06"/>
+          <trace target="LLR" ref="LLR-FRM-14"/>
+        </traces>
+      </test>
+      <test name="emits replace ops for StpFixture attrs in edit mode">
+        <purpose><![CDATA[Pins LLR-FRM-06 + LLR-FRM-07: in edit mode, buildOperations emits replace ops for StpFixture's @name and @source attributes.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-FRM-06"/>
+          <trace target="LLR" ref="LLR-FRM-07"/>
         </traces>
       </test>
       <test name="declares one walkthrough with seven steps in the documented order">
@@ -5019,8 +5052,21 @@ and shall not block the resolution flow.]]></text>
           <trace target="LLR" ref="LLR-FRM-11"/>
         </traces>
       </test>
-      <test name="resolves an SDD module locator to form params">
-        <purpose><![CDATA[Pins LLR-FRM-11: `resolveFormParams` maps `{tag:'module', value:'3.1'}` to an `OpenFormParams` with `type='SddModule'` and `basePath='/sdd/modules/module[path=3.1]'`.]]></purpose>
+      <test name="resolves an SDD module locator to form params with child fields">
+        <purpose><![CDATA[Pins LLR-FRM-11 + LLR-FRM-14: `resolveFormParams` maps `{tag:'module', value:'3.1'}` to an `OpenFormParams` with `type='SddModule'`, `basePath='/sdd/modules/module[path=3.1]'`, and `initial` containing all child element fields (purpose, responsibility, data_structures, algorithm).]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-FRM-11"/>
+          <trace target="LLR" ref="LLR-FRM-14"/>
+        </traces>
+      </test>
+      <test name="resolves an STP fixture locator to form params">
+        <purpose><![CDATA[Pins LLR-FRM-11: `resolveFormParams` maps `{tag:'fixture', value:'rtps'}` to an `OpenFormParams` with `type='StpFixture'` and `basePath='/stp/integration_environment/fixture[name=rtps]'`.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-FRM-11"/>
+        </traces>
+      </test>
+      <test name="returns undefined for a non-existent fixture">
+        <purpose><![CDATA[Pins LLR-FRM-11: when the locator targets a fixture name that does not exist in the parsed project, `resolveFormParams` returns `undefined`.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-FRM-11"/>
         </traces>
@@ -5032,7 +5078,7 @@ and shall not block the resolution flow.]]></text>
         </traces>
       </test>
       <test name="returns undefined for an unknown tag">
-        <purpose><![CDATA[Pins LLR-FRM-11: when the locator's `tag` is not one of the recognised item types (`hlr`, `llr`, `test`, `module`), `resolveFormParams` returns `undefined`.]]></purpose>
+        <purpose><![CDATA[Pins LLR-FRM-11: when the locator's `tag` is not one of the recognised item types (`hlr`, `llr`, `test`, `module`, `fixture`), `resolveFormParams` returns `undefined`.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-FRM-11"/>
         </traces>
@@ -5539,7 +5585,7 @@ and shall not block the resolution flow.]]></text>
         </traces>
       </test>
     </file>
-    <file path="tools/vscode-project-xml/test/unit/treeLogic.test.ts" role="unit-ts" count="25">
+    <file path="tools/vscode-project-xml/test/unit/treeLogic.test.ts" role="unit-ts" count="29">
       <header><![CDATA[Tier-1 unit tests for the Phase 10 extracted tree logic in tools/vscode-project-xml/src/treeView/treeLogic.ts. Drives `decorate`, `renderLabel`, `labelSeverity`, `groupSeverity`, `buildLocator`, `filterTraces`, `propagateBadgeSeverity`, and `buildTopLevelDescriptors` with hand-rolled ParsedProject / UiHintsIndex data so tree-structure logic is pinned without a VS Code host.]]></header>
       <test name="prepends badge when present">
         <purpose><![CDATA[Pins LLR-HUM-01: decorate prepends the badge emoji to the label.]]></purpose>
@@ -5574,6 +5620,42 @@ and shall not block the resolution flow.]]></text>
         <purpose><![CDATA[Pins LLR-HUM-01 + LLR-PSP-01: buildTopLevelDescriptors creates descriptor nodes for all payload groups.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-HUM-01"/>
+          <trace target="LLR" ref="LLR-PSP-01"/>
+          <trace target="HLR" ref="HLR-064"/>
+        </traces>
+      </test>
+      <test name="SDD module editArgs includes child element fields">
+        <purpose><![CDATA[Pins LLR-FRM-14 + LLR-PSP-07: buildSddDescriptor populates editArgs.formData with all child element fields (purpose, responsibility, data_structures, algorithm) so the edit form opens pre-filled with existing content.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-FRM-14"/>
+          <trace target="LLR" ref="LLR-PSP-07"/>
+          <trace target="HLR" ref="HLR-064"/>
+        </traces>
+      </test>
+      <test name="STP descriptor shows fixtures as editable children">
+        <purpose><![CDATA[Pins LLR-PSP-10: buildStpDescriptor renders fixtures as collapsible children with editArgs carrying type='StpFixture', correct basePath, and formData with name/source fields.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-PSP-10"/>
+          <trace target="HLR" ref="HLR-064"/>
+        </traces>
+      </test>
+      <test name="STP descriptor shows empty state when no STP section">
+        <purpose><![CDATA[Pins LLR-PSP-10: when no STP section exists, the node renders as 'STP (empty)' with no children and no contextValue.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-PSP-10"/>
+          <trace target="HLR" ref="HLR-064"/>
+        </traces>
+      </test>
+      <test name="STP descriptor shows 0 fixtures when STP exists but has no fixtures">
+        <purpose><![CDATA[Pins LLR-PSP-10: when STP exists but integration_environment has no fixtures, the node renders as 'STP (0 fixtures)' with stpGroup contextValue.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-PSP-10"/>
+          <trace target="HLR" ref="HLR-064"/>
+        </traces>
+      </test>
+      <test name="includes the typed builder types">
+        <purpose><![CDATA[Pins LLR-PSP-01: COVERED_TYPE_KEYS includes Hlr, Llr, Test, SddModule, and StpFixture so the generic builder skips them.]]></purpose>
+        <traces>
           <trace target="LLR" ref="LLR-PSP-01"/>
           <trace target="HLR" ref="HLR-064"/>
         </traces>

--- a/doc/SAR.md
+++ b/doc/SAR.md
@@ -88,7 +88,7 @@ itself integrated into the traceability matrix.
 | A03 | Injection | Applicable | Accepted risk | XML parsing uses `xml.etree.ElementTree` on locally-authored `Project.xml` files (trusted input). Jinja2 renders Markdown templates (not HTML served to browsers). Subprocess calls use fixed executables (`xmllint`). See §6 for details. |
 | A04 | Insecure Design | N/A | N/A | No authentication, session, or privilege-escalation surfaces. AI responses are schema-validated and diff-previewed before application. |
 | A05 | Security Misconfiguration | N/A | N/A | No server, container, or cloud configuration. Extension settings are user-scoped. |
-| A06 | Vulnerable/Outdated Components | Applicable | Open | npm audit reports 8 vulnerabilities (4 high, 4 moderate) in transitive dependencies. See §7 and [VR.md](VR.md). |
+| A06 | Vulnerable/Outdated Components | Applicable | Mitigated | npm audit reports 0 vulnerabilities after Phase 13/14 dependency updates (undici override pinned to `^6.21.1`). pip-audit clean. See §7 and [VR.md](VR.md). |
 | A07 | Identification/Authentication Failures | N/A | N/A | No user authentication. AI model access delegated to VS Code Copilot auth. |
 | A08 | Software/Data Integrity Failures | N/A | Mitigated | Extension bundled via esbuild; `.vsix` published through CI with a gated PAT. AI edits require user approval (no auto-apply). |
 | A09 | Security Logging/Monitoring Failures | N/A | N/A | Local tool — no runtime logging requirements. AI provenance logged to `.edit_doc/ai_history.jsonl`. |
@@ -96,60 +96,53 @@ itself integrated into the traceability matrix.
 
 ## 6. Static Analysis Findings
 
-Automated SAST was run on 2026-05-10 using Bandit, ESLint + eslint-plugin-security, and Semgrep. Findings are categorised below with dispositions.
+Automated SAST was last run on 2026-05-16 using Bandit, ESLint + eslint-plugin-security, and Semgrep. Findings are categorised below with dispositions. The summary table reflects the current scan; previously-reported HIGH/MEDIUM Bandit findings (B701 Jinja2, B314 ElementTree, B405 import) were resolved during Phase 13 via `defusedxml` and Jinja2 autoescape configuration.
 
-### 6.1 Bandit — Python Security (30 findings)
+### 6.1 Bandit — Python Security (7 findings: 0 high, 0 medium, 7 low)
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
-| HIGH | Bandit | B701 (Jinja2 autoescape) | render_doc.py:1380 | Accepted risk | Renders Markdown templates, not HTML served to browsers. XSS is not applicable — output is `.md` files consumed by GitHub/VS Code renderers, not a web app. |
-| MEDIUM | Bandit | B314 (xml.etree.ElementTree.parse) | ai/translators.py:87, :439; coverage_report.py:20; lint_project.py:161; project_edit.py:268, :805, :826; render_doc.py:191, :290, :728, :968, :1032; test_results_report.py:27 | Accepted risk | All 13 sites parse locally-authored `Project.xml` or CI-generated XML reports (JUnit, Cobertura). These are trusted files under the developer's control — not untrusted network input. XXE is not exploitable in this context. |
-| LOW | Bandit | B405 (xml.etree.ElementTree import) | ai/translators.py:85, :437; coverage_report.py:15; lint_project.py:44; project_edit.py:264, :803, :824; render_doc.py:19; test_results_report.py:20 | Accepted risk | Import-level companion to B314 above — same justification applies. |
 | LOW | Bandit | B404 (subprocess import) | lint_project.py:42; render_doc.py:1362 | Accepted risk | `subprocess` is used to invoke `xmllint` with fixed arguments for XSD validation. No user-controlled input reaches the command line. |
-| LOW | Bandit | B603/B607 (subprocess call) | lint_project.py:203; render_doc.py:1375 | Accepted risk | Invokes `xmllint` with a hardcoded executable name and file paths derived from the workspace (not user-supplied strings from untrusted sources). |
+| LOW | Bandit | B603 (subprocess call) | lint_project.py:203; render_doc.py:1375 | Accepted risk | Invokes `xmllint` with a hardcoded executable name and file paths derived from the workspace (not user-supplied strings from untrusted sources). |
+| LOW | Bandit | B607 (partial executable path) | lint_project.py:203 | Accepted risk | Companion to B603 above — `xmllint` resolved via PATH on the developer's machine. |
 | LOW | Bandit | B101 (assert) | project_edit.py:409, :420 | Accepted risk | Assertions guard internal invariants in edit logic; these are developer-facing tools, not production services where `-O` stripping is a concern. |
 
-### 6.2 ESLint — TypeScript Security + Quality (1 error, 48 warnings)
+### 6.2 ESLint — TypeScript Security + Quality (0 errors, 48 warnings)
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
-| error | ESLint | `no-useless-escape` | formLogic.ts:412 | Open | Unnecessary escape character in regex — should be fixed. |
 | warning | ESLint | `security/detect-object-injection` (15×) | capabilities.ts, treeMenu.ts, QuickFixProvider.ts, coverageLensLogic.ts, lintMapping.ts, formLogic.ts, formMain.tsx, treeLogic.ts, freshness.ts, locator.ts | Accepted risk | All flagged sites use string keys from schema-defined enums or parsed JSON-RPC responses, not arbitrary user input. Object injection is not exploitable. |
 | warning | ESLint | `security/detect-non-literal-fs-filename` (20×) | initProject.ts, scaffoldTools.ts, sidecar.ts, freshness.ts, paths.ts, MergeConflictResolver.ts | Accepted risk | File paths are constructed from `vscode.workspace.workspaceFolders` and known subpaths — all within the trusted workspace boundary. |
 | warning | ESLint | `security/detect-non-literal-regexp` (5×) | fixes.ts, coverageLensLogic.ts, locator.ts | Accepted risk | Regex patterns are built from schema-derived element names and id attributes, not arbitrary user input. |
 | warning | ESLint | `security/detect-unsafe-regex` (2×) | fixes.ts:95, locator.ts:182 | Accepted risk | Patterns match fixed XML id/tag formats with bounded repetition; ReDoS is not feasible on the input domain. |
 
-### 6.3 Semgrep — OWASP (44 findings)
+The previously-reported `no-useless-escape` error in `formLogic.ts:412` was fixed during Phase 13 — ESLint now reports zero errors.
+
+### 6.3 Semgrep — OWASP (31 findings)
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
-| ERROR | Semgrep | `use-defused-xml-parse` (13×) | translators.py, coverage_report.py, lint_project.py, project_edit.py, render_doc.py, test_results_report.py | Accepted risk | Same sites as Bandit B314 — parses trusted local XML files. See §6.1. |
-| WARNING | Semgrep | `direct-use-of-jinja2` (2×) | render_doc.py:1380, :1389 | Accepted risk | Same as Bandit B701 — Markdown output, no browser XSS vector. |
-| WARNING | Semgrep | `path-join-resolve-traversal` (16×) | prepackage.js, initProject.ts, quickFixes.ts, scaffoldTools.ts, MergeConflictResolver.ts, documents.ts, paths.ts | Accepted risk | All paths are rooted at the VS Code workspace folder. No user-controlled path segments from untrusted sources. |
-| WARNING | Semgrep | `detect-non-literal-regexp` (11×) | fixes.ts, coverageLensLogic.ts, locator.ts | Accepted risk | Same as ESLint `detect-non-literal-regexp` — schema-derived patterns. |
+| WARNING | Semgrep | `direct-use-of-jinja2` (2×) | render_doc.py:1380, :1390 | Accepted risk | Markdown output, no browser XSS vector. Autoescape configured for HTML/XML extensions in Phase 13. |
+| WARNING | Semgrep | `path-join-resolve-traversal` (20×) | prepackage.js, initProject.ts, quickFixes.ts, scaffoldTools.ts, MergeConflictResolver.ts, documents.ts, paths.ts | Accepted risk | All paths are rooted at the VS Code workspace folder. No user-controlled path segments from untrusted sources. |
+| WARNING | Semgrep | `detect-non-literal-regexp` (9×) | fixes.ts, coverageLensLogic.ts, locator.ts | Accepted risk | Same as ESLint `detect-non-literal-regexp` — schema-derived patterns. |
+
+The previously-reported `use-defused-xml-parse` ERROR findings (13×) were resolved during Phase 13 by switching XML parsing call sites to `defusedxml.ElementTree`.
 
 ## 7. Dependency Security
 
 | Ecosystem | Scanner | Critical | High | Medium | Low |
 |-----------|---------|----------|------|--------|-----|
 | Python (pip) | pip-audit | 0 | 0 | 0 | 0 |
-| Node.js (npm) | npm audit | 0 | 4 | 4 | 0 |
+| Node.js (npm) | npm audit | 0 | 0 | 0 | 0 |
 
 **pip-audit:** 0 vulnerabilities across 93 packages — clean.
 
-**npm audit:** 8 vulnerabilities in transitive dependencies (all have
-fixes available via `npm audit fix`):
-- **High (4):** fast-uri (path traversal), mocha → serialize-javascript
-  (RCE via RegExp.flags), serialize-javascript (same), undici
-  (insufficiently random values).
-- **Moderate (4):** @vscode/vsce → xml2js (prototype pollution),
-  cheerio → undici, esbuild (dev server request leak), xml2js
-  (prototype pollution).
-
-All high/moderate npm findings are in **dev-only or build-only**
-transitive dependencies (mocha, esbuild, @vscode/vsce, cheerio) —
-none are shipped in the packaged `.vsix`. See [VR.md](VR.md) for
-individual disposition.
+**npm audit:** 0 vulnerabilities — clean. The previous 8 transitive
+high/moderate findings (fast-uri, serialize-javascript, undici,
+xml2js, esbuild) were resolved by Phase 13 dependency updates and
+the Phase 14 pinning of the `undici` override to `^6.21.1`. The
+affected packages remain dev-/build-only and are not shipped in the
+packaged `.vsix`. See [VR.md](VR.md) §7 for the resolution history.
 
 ## 8. Input Validation & Injection Surfaces
 
@@ -177,20 +170,22 @@ individual disposition.
 
 | Priority | Recommendation | Component | Expected Outcome |
 |----------|---------------|-----------|-----------------|
-| Low | Fix ESLint `no-useless-escape` error in `formLogic.ts:412` | VS Code extension | Zero ESLint errors; CI gate passes cleanly |
-| Low | Run `npm audit fix` to resolve transitive dependency vulnerabilities | VS Code extension | Reduce npm audit findings from 8 to 0 (all fixes available) |
-| Info | Consider adding `defusedxml` for defence-in-depth, even though XML input is trusted | Python tools | Silences Bandit B314/B405 and Semgrep `use-defused-xml-parse` without changing behaviour |
+| Info | Continue running `make -C tools analyze` on every PR (already wired into CI) | Dev toolchain | Regressions in finding counts caught at PR time |
+| Info | Re-evaluate `defusedxml` adoption if any new XML parsing call sites are added | Python tools | Maintain Semgrep `use-defused-xml-parse` clean baseline |
 | Info | Install Semgrep in local dev environment for full local scan coverage | Dev toolchain | Local results match CI |
 
 ## 11. Residual Risk Summary
 
 **Overall posture: Low risk.**
 
-All SAST findings are accepted risks with documented justification —
-the tool operates on trusted local files in a desktop environment
-with no network attack surface. The one actionable ESLint error
-(`no-useless-escape`) is cosmetic. npm dependency vulnerabilities are
-in dev/build-only transitive packages not shipped to end users.
+All remaining SAST findings are accepted risks with documented
+justification — the tool operates on trusted local files in a
+desktop environment with no network attack surface. Phase 13
+resolved every HIGH/MEDIUM Bandit finding (via `defusedxml` and
+Jinja2 autoescape), the previously-flagged ESLint error
+(`no-useless-escape`), and the Semgrep `use-defused-xml-parse`
+ERROR set. Phase 14's dependency-tree refresh brings npm audit to
+zero. There are currently no Open findings.
 
 **Assumptions:**
 - Users run the extension in a trusted VS Code workspace.
@@ -209,5 +204,5 @@ in dev/build-only transitive packages not shipped to end users.
 
 | Role | Name | Date | Signature |
 |------|------|------|-----------|
-| Author | AI-assisted (PR prompt) | 2026-05-10 | |
+| Author | AI-assisted (PR prompt) | 2026-05-16 | |
 | Reviewer | | | |

--- a/doc/SDP.md
+++ b/doc/SDP.md
@@ -25,6 +25,7 @@
 | [11](#phase-11--recordreplay-test-harness-for-ai-authoring-pipeline) | Record/replay test harness for AI authoring pipeline. | ✅ Done — `pipeline.record_exchange()` writes `.bundle.json`/`.response.json` fixture pairs when `TRACER_AI_RECORD_DIR` is set; 11 curated fixtures in `test/fixtures/ai_recordings/` covering every intent (including gap.fix full cascade); `test/test_ai_integration.py` replays all fixtures through translator → `apply_edit` asserting lint-clean XML and resolved placeholders; 5 previously unregistered AI test files registered in Project.xml; Developers Guide §18 documents recording mode. |
 | [12](#phase-12--update-ui-tests-and-ci) | Update UI tests and CI: fix double-run on PR, stabilise ExTester UI tests with polling helpers, add provider-level integration tests with FakeSidecarClient, JUnit test-results reporting in CI. | ✅ Done |
 | [13](#phase-13--static-analysis-and-vulnerabilities) | Address lint warnings and vulnerabilities; security audit report. | ✅ Done — Bandit, pip-audit, ESLint + eslint-plugin-security, npm audit, and Semgrep integrated into `tools/Makefile` (`analyze` umbrella target); `tools/analyze_report.py` generates a consolidated Markdown report from JSON outputs with `--exit-code` flag for CI gating (errors block, warnings pass); CI workflow (`ci.yml`) runs all five analyzers on every PR with a sticky comment and GitHub Step Summary; PR prompt (`PR.prompt.md`) updated to run static analysis, update SAR.md §5/§6/§7, triage Dependabot alerts via `gh api`, and update VR.md §2–§7. |
+| [14](#phase-14--update-vs-code-extension-forms-to-work-with-sdd-and-stp) | Update VS Code extension forms to work with SDD and STP. | ✅ Done — `buildStpDescriptor` renders STP as a collapsible tree node with one leaf per `<fixture>` under `<stp>/<integration_environment>`; new `addStpFixture` context menu entry on the STP group node; SDD module edit form pre-populates all child fields (`purpose`, `responsibility`, `data_structures`, `algorithm`) — not just `path`/`title`; `resolveFormParams` adds a `fixture` case so coverage-hint clicks navigate to STP fixture edit forms; `ParsedSddModule` / `ParsedStpFixture` typings widened to expose child fields over the sidecar; 7 new unit tests added (treeLogic + formPanel) pinning LLR-FRM-14 and LLR-PSP-10; undici override pinned to `^6.21.1` to keep transitive dep tree clean. |
 
 
 **Owner:** TBD
@@ -1360,6 +1361,52 @@ Create the following agents and prompts
    vulnerabilities, determines if they are applicable, updates
    them on GitHub, and updates the Vulnerability Report
 
+### Phase 14 — Update VS Code Extension Forms to Work with SDD and STP
+1. Extend `buildStpDescriptor` so the STP tree group renders as a
+   collapsible node `STP (N fixtures)` whose children are the
+   `<fixture>` elements under `<stp>/<integration_environment>`,
+   each carrying `editArgs` for the schema-driven popup edit
+   dialog (LLR-PSP-10).
+2. Add an `addStpFixture` context-menu entry on the STP group
+   (`viewItem == stpGroup`) and extend the existing
+   `renderAndPreview` menu predicate so the STP group is
+   render-and-previewable from the tree (parity with `hlrsGroup`,
+   `llrsGroup`, `testsGroup`, `sddGroup`).
+3. Fix the SDD module edit form so it pre-populates ALL child
+   element fields declared in the XSD `<ui:form>` annotation
+   (`purpose`, `responsibility`, `data_structures`, `algorithm`)
+   in addition to the attribute fields (`path`, `title`) — both
+   when opened via `editPayload` from the tree and when opened
+   via `resolveFormParams` from a coverage-hint click
+   (LLR-FRM-14). Multi-valued children (e.g. multiple
+   `<responsibility>` elements) are joined with newline separators
+   so the textarea widget displays them as a block.
+4. Add a `fixture` case to `resolveFormParams` so coverage-hint
+   clicks on STP fixtures resolve to an `OpenFormParams` with
+   `type='StpFixture'`, `basePath='/stp/integration_environment/fixture[name=X]'`,
+   and `initial` containing `name` and `source` fields
+   (LLR-FRM-11 extension).
+5. Widen the sidecar typings (`ParsedSddModule`, `ParsedStpFixture`,
+   `ParsedStp.integration_environment.fixtures`) so the new child
+   fields are exposed through `parse_project_xml` over JSON-RPC.
+6. Add `StpFixture` to `COVERED_TYPE_KEYS` so STP fixtures get
+   coverage-badge propagation alongside HLR/LLR/Test/SddModule.
+7. Add unit-test coverage: `buildSddDescriptor` includes child
+   element fields in `editArgs.formData`; `buildStpDescriptor`
+   renders fixtures as editable children; `buildOperations`
+   emits replace ops for `SddModule` child fields and
+   `StpFixture` attrs in edit mode; `resolveFormParams` handles
+   the new `fixture` tag plus the not-found case; the SDD module
+   locator test asserts the full `initial` payload.
+8. Pin `undici` override to `^6.21.1` in the extension
+   `package.json` so the transitive dep tree stays on the
+   currently-clean major; refresh `package-lock.json`.
+9. Acceptance: tree shows STP fixtures as editable leaves;
+   double-clicking an SDD module or STP fixture opens the edit
+   form pre-populated; right-clicking the STP group offers
+   `Add STP Fixture`; existing tests stay green; the seven new
+   unit tests pass.
+
 ## 9. Risks & Open Questions
 
 *   **Python discovery.** Need a robust strategy to find Python on
@@ -1435,7 +1482,8 @@ post-baseline improvements tracked as open GitHub issues.
 | 10 | Refactor providers (humble object) | TypeScript | medium | post-baseline |
 | 11 | Record/replay AI test harness | Python | medium | post-baseline |
 | 12 | SDP template | Python + Jinja2 | small | post-baseline |
-| TBD | Lint warnings + security audit | Python + toolchain | small-medium | post-baseline |
+| 13 | Lint warnings + security audit | Python + toolchain | small-medium | post-baseline |
+| 14 | SDD/STP form completeness | TypeScript | small | post-baseline |
 
 ## 11. Out-of-Scope Follow-ups
 

--- a/doc/VR.md
+++ b/doc/VR.md
@@ -1,7 +1,7 @@
 # Vulnerability Report: TraceR (tracer)
 
-**Version:** 0.2
-**Date:** 2026-05-10
+**Version:** 0.3
+**Date:** 2026-05-16
 **Author(s):** AI-assisted (via PR prompt)
 
 > **How to use this template.** This is a living document — update it
@@ -34,12 +34,16 @@ For the broader security assessment, see the companion
 | Medium | 0 | 0 | 0 | 6 | 0 |
 | Low | 0 | 0 | 0 | 1 | 0 |
 
-**Trend:** First baseline assessment — all 10 Dependabot alerts
-dismissed as dev-only/build-only dependencies not shipped in the
-`.vsix`. SAST findings assessed in [SAR.md](SAR.md) §6 — all
-accepted risks with justification (trusted local input context).
+**Trend:** No open Dependabot alerts. npm audit and pip-audit both
+report zero vulnerabilities as of 2026-05-16 — the 10 previously
+dismissed advisories no longer appear in the current scan after
+the Phase 14 dependency-tree refresh (undici override pinned to
+`^6.21.1`). They remain listed in §6 for audit history and are
+also mirrored into §7 as resolved. SAST findings are assessed in
+[SAR.md](SAR.md) §6 — all accepted risks with justification
+(trusted local input context).
 
-**Last updated:** 2026-05-10
+**Last updated:** 2026-05-16
 
 ## 3. Scanning Configuration
 
@@ -54,7 +58,7 @@ accepted risks with justification (trusted local input context).
 
 ## 4. Open Vulnerabilities
 
-No open vulnerabilities as of 2026-05-10.
+No open vulnerabilities as of 2026-05-16.
 
 ### 4.1 Critical
 
@@ -94,7 +98,8 @@ analysis findings with "Accepted risk" disposition).
 
 All 10 Dependabot alerts dismissed on 2026-05-10. All are in
 dev-only or build-only npm transitive dependencies not shipped in
-the packaged `.vsix`.
+the packaged `.vsix`. As of 2026-05-16 these CVEs no longer appear
+in npm audit — see §7 for the resolved entries.
 
 | CVE / ID | Component | Severity | Reason for Dismissal |
 |----------|-----------|----------|---------------------|
@@ -113,7 +118,16 @@ the packaged `.vsix`.
 
 | CVE / ID | Component | Severity | Resolution | Date Fixed |
 |----------|-----------|----------|-----------|------------|
-| — | — | — | No resolved vulnerabilities yet (first baseline). | — |
+| CVE-2026-6322 | fast-uri (npm) | High | Resolved via transitive upgrade through ajv/@rjsf; no longer present in npm audit. | 2026-05-16 |
+| CVE-2026-6321 | fast-uri (npm) | High | Resolved via transitive upgrade through ajv/@rjsf; no longer present in npm audit. | 2026-05-16 |
+| GHSA serialize-javascript | serialize-javascript (npm) | High | Resolved via `serialize-javascript: 7.0.5` override in extension `package.json`. | 2026-05-16 |
+| CVE-2026-1527 | undici (npm) | Medium | Resolved via `undici: ^6.21.1` override pinning in extension `package.json`. | 2026-05-16 |
+| CVE-2026-1525 | undici (npm) | Medium | Resolved via `undici: ^6.21.1` override pinning. | 2026-05-16 |
+| CVE-2025-22150 | undici (npm) | Medium | Resolved via `undici: ^6.21.1` override pinning. | 2026-05-16 |
+| CVE-2023-0842 | xml2js (npm) | Medium | Resolved via @vscode/vsce transitive upgrade; no longer present in npm audit. | 2026-05-16 |
+| CVE-2026-34043 | serialize-javascript (npm) | Medium | Resolved via override (see High row above). | 2026-05-16 |
+| GHSA esbuild | esbuild (npm) | Medium | Resolved via esbuild upgrade in extension dev dependencies. | 2026-05-16 |
+| CVE-2025-47279 | undici (npm) | Low | Resolved via `undici: ^6.21.1` override pinning. | 2026-05-16 |
 
 ## 8. Process
 

--- a/tools/vscode-project-xml/package-lock.json
+++ b/tools/vscode-project-xml/package-lock.json
@@ -2782,6 +2782,15 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -7767,15 +7776,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=20.18.1"
-      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/tools/vscode-project-xml/package.json
+++ b/tools/vscode-project-xml/package.json
@@ -300,8 +300,13 @@
           "group": "navigation"
         },
         {
+          "command": "projectXml.addStpFixture",
+          "when": "view == projectXml.tree && viewItem == stpGroup",
+          "group": "navigation"
+        },
+        {
           "command": "projectXml.renderAndPreview",
-          "when": "view == projectXml.tree && viewItem =~ /^(hlrsGroup|llrsGroup|testsGroup|sddGroup)$/",
+          "when": "view == projectXml.tree && viewItem =~ /^(hlrsGroup|llrsGroup|testsGroup|sddGroup|stpGroup)$/",
           "group": "render@1"
         },
         {
@@ -540,7 +545,7 @@
     "vscode-extension-tester": "^8.23.0"
   },
   "overrides": {
-    "undici": "^7.25.0",
+    "undici": "^6.21.1",
     "serialize-javascript": "7.0.5"
   }
 }

--- a/tools/vscode-project-xml/src/commands/forms.ts
+++ b/tools/vscode-project-xml/src/commands/forms.ts
@@ -139,6 +139,8 @@ export async function addModule(
             title: '',
             purpose: '',
             responsibility: '',
+            data_structures: '',
+            algorithm: '',
         },
         appendPath: '/sdd/modules/module/-',
     });

--- a/tools/vscode-project-xml/src/forms/formLogic.ts
+++ b/tools/vscode-project-xml/src/forms/formLogic.ts
@@ -375,8 +375,30 @@ export function resolveFormParams(
                     return {
                         type: 'SddModule',
                         title: `Edit ${value}`,
-                        initial: { ...m } as Record<string, unknown>,
+                        initial: {
+                            path: m.path,
+                            title: m.title ?? '',
+                            purpose: m.purpose ?? '',
+                            responsibility: ((m as Record<string, unknown>).responsibilities as string[] ?? []).join('\n'),
+                            data_structures: m.data_structures ?? '',
+                            algorithm: m.algorithm ?? '',
+                        } as Record<string, unknown>,
                         basePath: `/sdd/modules/module[path=${value}]`,
+                    };
+                }
+            }
+            return undefined;
+        }
+        case 'fixture': {
+            const fixtures = (parsed.stp?.integration_environment as
+                { fixtures?: Array<{ name: string; source?: string }> } | undefined)?.fixtures ?? [];
+            for (const f of fixtures) {
+                if (f.name === value) {
+                    return {
+                        type: 'StpFixture',
+                        title: `Edit ${value}`,
+                        initial: { name: f.name, source: f.source ?? '' } as Record<string, unknown>,
+                        basePath: `/stp/integration_environment/fixture[name=${value}]`,
                     };
                 }
             }

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -630,6 +630,10 @@ export interface ParsedTrace {
 export interface ParsedSddModule {
     path?: string;
     title?: string;
+    purpose?: string;
+    responsibilities?: string[];
+    data_structures?: string;
+    algorithm?: string;
     ui?: UiHints | null;
 }
 
@@ -637,7 +641,17 @@ export interface ParsedSdd {
     modules?: ParsedSddModule[];
 }
 
+export interface ParsedStpFixture {
+    name: string;
+    source?: string;
+    ui?: UiHints | null;
+}
+
 export interface ParsedStp {
+    integration_environment?: {
+        fixtures?: ParsedStpFixture[];
+        [key: string]: unknown;
+    };
     [key: string]: unknown;
 }
 

--- a/tools/vscode-project-xml/src/treeView/treeLogic.ts
+++ b/tools/vscode-project-xml/src/treeView/treeLogic.ts
@@ -129,6 +129,7 @@ export const COVERED_TYPE_KEYS = new Set([
     'Llr',
     'Test',
     'SddModule',
+    'StpFixture',
 ]);
 
 // ---------------------------------------------------------------------
@@ -287,7 +288,14 @@ function buildSddDescriptor(
             editArgs: m.path ? {
                 type: 'SddModule',
                 basePath: `/sdd/modules/module[path=${m.path}]`,
-                formData: { path: m.path, title: m.title ?? '' },
+                formData: {
+                    path: m.path,
+                    title: m.title ?? '',
+                    purpose: m.purpose ?? '',
+                    responsibility: (m.responsibilities ?? []).join('\n'),
+                    data_structures: m.data_structures ?? '',
+                    algorithm: m.algorithm ?? '',
+                },
                 title: `Edit ${m.path}`,
             } : undefined,
         } as TreeNodeDescriptor)),
@@ -296,13 +304,29 @@ function buildSddDescriptor(
 
 function buildStpDescriptor(project: ParsedProject): TreeNodeDescriptor {
     const present = project.stp != null;
+    const fixtures = (project.stp?.integration_environment?.fixtures ?? []) as
+        import('../sidecar').ParsedStpFixture[];
     return {
-        label: present ? 'STP' : 'STP (empty)',
-        collapsible: false,
+        label: present ? `STP (${fixtures.length} fixtures)` : 'STP (empty)',
+        collapsible: fixtures.length > 0,
         icon: 'checklist',
-        contextValue: present ? 'revealable' : undefined,
+        contextValue: present ? 'stpGroup' : undefined,
         locator: present ? { tag: 'stp', value: '' } : undefined,
         docId: 'STP',
+        children: fixtures.map((f) => ({
+            label: f.name || '(unnamed fixture)',
+            collapsible: false,
+            locator: f.name
+                ? { tag: 'fixture', attr: 'name', value: f.name }
+                : undefined,
+            ui: f.ui,
+            editArgs: f.name ? {
+                type: 'StpFixture',
+                basePath: `/stp/integration_environment/fixture[name=${f.name}]`,
+                formData: { name: f.name, source: f.source ?? '' },
+                title: `Edit ${f.name}`,
+            } : undefined,
+        } as TreeNodeDescriptor)),
     };
 }
 

--- a/tools/vscode-project-xml/test/unit/formPanel.test.ts
+++ b/tools/vscode-project-xml/test/unit/formPanel.test.ts
@@ -230,6 +230,65 @@ describe('buildOperations (Phase 4 — schema-driven attribute split)', () => {
             text: 'body',
         });
     });
+
+    it('emits replace ops for SddModule attrs and child fields in edit mode', () => {
+        const base = '/sdd/modules/module[path=src/foo.ts]';
+        const ops = buildOperations(
+            {
+                type: 'SddModule',
+                title: 'Edit src/foo.ts',
+                initial: {},
+                basePath: base,
+            },
+            {
+                path: 'src/foo.ts',
+                title: 'Foo Module',
+                purpose: 'Implements foo logic.',
+                responsibility: 'Owns foo state.',
+                data_structures: 'FooRecord',
+                algorithm: 'Binary search.',
+            },
+            [
+                { kind: 'attr',  target: 'path',            field: 'text',  required: false },
+                { kind: 'attr',  target: 'title',           field: 'text',  required: false },
+                { kind: 'child', target: 'purpose',         field: 'cdata', required: false },
+                { kind: 'child', target: 'responsibility',  field: 'cdata', required: false },
+                { kind: 'child', target: 'data_structures', field: 'cdata', required: false },
+                { kind: 'child', target: 'algorithm',       field: 'cdata', required: false },
+            ],
+        );
+        const paths = ops.map((o) => `${o.op} ${o.path}`).sort();
+        assert.deepEqual(paths, [
+            `replace ${base}/@path`,
+            `replace ${base}/@title`,
+            `replace ${base}/algorithm`,
+            `replace ${base}/data_structures`,
+            `replace ${base}/purpose`,
+            `replace ${base}/responsibility`,
+        ]);
+    });
+
+    it('emits replace ops for StpFixture attrs in edit mode', () => {
+        const base = '/stp/integration_environment/fixture[name=rtps]';
+        const ops = buildOperations(
+            {
+                type: 'StpFixture',
+                title: 'Edit rtps',
+                initial: {},
+                basePath: base,
+            },
+            { name: 'rtps', source: 'docker compose up' },
+            [
+                { kind: 'attr', target: 'name',   field: 'text', required: true },
+                { kind: 'attr', target: 'source', field: 'text', required: false },
+            ],
+        );
+        const paths = ops.map((o) => `${o.op} ${o.path}`).sort();
+        assert.deepEqual(paths, [
+            `replace ${base}/@name`,
+            `replace ${base}/@source`,
+        ]);
+    });
 });
 
 describe('package.json walkthrough contribution (Phase 4)', () => {
@@ -479,7 +538,21 @@ function makeNestedParsed(): ParsedProject {
             },
         ],
         sdd: {
-            modules: [{ path: '3.1', title: 'Module One' }],
+            modules: [{
+                path: '3.1',
+                title: 'Module One',
+                purpose: 'Does stuff.',
+                responsibilities: ['Owns the thing.', 'Cleans up.'],
+                data_structures: 'SomeStruct',
+                algorithm: 'DFS traversal.',
+            }],
+        },
+        stp: {
+            integration_environment: {
+                fixtures: [
+                    { name: 'rtps', source: 'docker compose up' },
+                ],
+            },
         },
     } as unknown as ParsedProject;
 }
@@ -516,7 +589,7 @@ describe('resolveFormParams (coverage link → open form)', () => {
         assert.equal(result.basePath, '/tests/file[path=test/test_alpha.py]/test[name=test_alpha]');
     });
 
-    it('resolves an SDD module locator to form params', () => {
+    it('resolves an SDD module locator to form params with child fields', () => {
         const result = resolveFormParams(
             makeNestedParsed(),
             { tag: 'module', value: '3.1' },
@@ -524,6 +597,34 @@ describe('resolveFormParams (coverage link → open form)', () => {
         assert.ok(result);
         assert.equal(result.type, 'SddModule');
         assert.equal(result.basePath, '/sdd/modules/module[path=3.1]');
+        const init = result.initial as Record<string, unknown>;
+        assert.equal(init.path, '3.1');
+        assert.equal(init.title, 'Module One');
+        assert.equal(init.purpose, 'Does stuff.');
+        assert.equal(init.responsibility, 'Owns the thing.\nCleans up.');
+        assert.equal(init.data_structures, 'SomeStruct');
+        assert.equal(init.algorithm, 'DFS traversal.');
+    });
+
+    it('resolves an STP fixture locator to form params', () => {
+        const result = resolveFormParams(
+            makeNestedParsed(),
+            { tag: 'fixture', attr: 'name', value: 'rtps' },
+        );
+        assert.ok(result);
+        assert.equal(result.type, 'StpFixture');
+        assert.equal(result.basePath, '/stp/integration_environment/fixture[name=rtps]');
+        const init = result.initial as Record<string, unknown>;
+        assert.equal(init.name, 'rtps');
+        assert.equal(init.source, 'docker compose up');
+    });
+
+    it('returns undefined for a non-existent fixture', () => {
+        const result = resolveFormParams(
+            makeNestedParsed(),
+            { tag: 'fixture', attr: 'name', value: 'nonexistent' },
+        );
+        assert.equal(result, undefined);
     });
 
     it('returns undefined for a non-existent item', () => {

--- a/tools/vscode-project-xml/test/unit/treeLogic.test.ts
+++ b/tools/vscode-project-xml/test/unit/treeLogic.test.ts
@@ -183,6 +183,91 @@ describe('treeLogic', () => {
             assert.ok(labels.some(l => l.startsWith('SDD')));
             assert.ok(labels.some(l => l.startsWith('STP')));
         });
+
+        it('SDD module editArgs includes child element fields', () => {
+            const project: ParsedProject = {
+                hlrs: [], llrs: [], tests: [],
+                sdd: {
+                    modules: [{
+                        path: 'src/foo.ts',
+                        title: 'Foo',
+                        purpose: 'Does foo.',
+                        responsibilities: ['Owns state.', 'Handles events.'],
+                        data_structures: 'FooData record.',
+                        algorithm: 'Linear scan.',
+                    }],
+                },
+            } as unknown as ParsedProject;
+            const nodes = buildTopLevelDescriptors(project, undefined);
+            const sdd = nodes.find(n => n.label.startsWith('SDD'));
+            assert.ok(sdd?.children?.length === 1);
+            const mod = sdd.children[0];
+            assert.ok(mod.editArgs);
+            assert.equal(mod.editArgs.type, 'SddModule');
+            assert.equal(mod.editArgs.basePath, '/sdd/modules/module[path=src/foo.ts]');
+            const fd = mod.editArgs.formData;
+            assert.equal(fd.path, 'src/foo.ts');
+            assert.equal(fd.title, 'Foo');
+            assert.equal(fd.purpose, 'Does foo.');
+            assert.equal(fd.responsibility, 'Owns state.\nHandles events.');
+            assert.equal(fd.data_structures, 'FooData record.');
+            assert.equal(fd.algorithm, 'Linear scan.');
+        });
+
+        it('STP descriptor shows fixtures as editable children', () => {
+            const project: ParsedProject = {
+                hlrs: [], llrs: [], tests: [],
+                sdd: { modules: [] },
+                stp: {
+                    integration_environment: {
+                        fixtures: [
+                            { name: 'rtps', source: 'docker compose up' },
+                            { name: 'db', source: 'pg_ctl start' },
+                        ],
+                    },
+                },
+            } as unknown as ParsedProject;
+            const nodes = buildTopLevelDescriptors(project, undefined);
+            const stp = nodes.find(n => n.label.startsWith('STP'));
+            assert.ok(stp);
+            assert.equal(stp.label, 'STP (2 fixtures)');
+            assert.equal(stp.collapsible, true);
+            assert.equal(stp.contextValue, 'stpGroup');
+            assert.ok(stp.children?.length === 2);
+            const rtps = stp.children[0];
+            assert.equal(rtps.label, 'rtps');
+            assert.ok(rtps.editArgs);
+            assert.equal(rtps.editArgs.type, 'StpFixture');
+            assert.equal(rtps.editArgs.basePath, '/stp/integration_environment/fixture[name=rtps]');
+            assert.deepEqual(rtps.editArgs.formData, { name: 'rtps', source: 'docker compose up' });
+        });
+
+        it('STP descriptor shows empty state when no STP section', () => {
+            const project: ParsedProject = {
+                hlrs: [], llrs: [], tests: [],
+                sdd: { modules: [] },
+            } as unknown as ParsedProject;
+            const nodes = buildTopLevelDescriptors(project, undefined);
+            const stp = nodes.find(n => n.label.startsWith('STP'));
+            assert.ok(stp);
+            assert.equal(stp.label, 'STP (empty)');
+            assert.equal(stp.collapsible, false);
+            assert.equal(stp.contextValue, undefined);
+        });
+
+        it('STP descriptor shows 0 fixtures when STP exists but has no fixtures', () => {
+            const project: ParsedProject = {
+                hlrs: [], llrs: [], tests: [],
+                sdd: { modules: [] },
+                stp: {},
+            } as unknown as ParsedProject;
+            const nodes = buildTopLevelDescriptors(project, undefined);
+            const stp = nodes.find(n => n.label.startsWith('STP'));
+            assert.ok(stp);
+            assert.equal(stp.label, 'STP (0 fixtures)');
+            assert.equal(stp.collapsible, false);
+            assert.equal(stp.contextValue, 'stpGroup');
+        });
     });
 
     describe('buildGenericPayloadDescriptors', () => {
@@ -201,11 +286,12 @@ describe('treeLogic', () => {
     });
 
     describe('COVERED_TYPE_KEYS', () => {
-        it('includes the four legacy types', () => {
+        it('includes the typed builder types', () => {
             assert.ok(COVERED_TYPE_KEYS.has('Hlr'));
             assert.ok(COVERED_TYPE_KEYS.has('Llr'));
             assert.ok(COVERED_TYPE_KEYS.has('Test'));
             assert.ok(COVERED_TYPE_KEYS.has('SddModule'));
+            assert.ok(COVERED_TYPE_KEYS.has('StpFixture'));
         });
     });
 });


### PR DESCRIPTION
## Summary

Completes the SDD module and STP fixture editing experience in the VS Code extension, plus PR-prompt doc maintenance for SDP/SAR/VR.

### Tree + forms
- Render STP tree group as collapsible `STP (N fixtures)` with one editable leaf per `<fixture>` under `<stp>/<integration_environment>`
- Add `addStpFixture` context-menu entry on the STP group; extend `renderAndPreview` to include `stpGroup`
- Pre-populate SDD module edit form with all child fields (`purpose`, `responsibility`, `data_structures`, `algorithm`) — both via `editPayload` and `resolveFormParams`
- Add `fixture` case to `resolveFormParams` so coverage-hint clicks open the STP fixture edit form
- Widen sidecar typings to expose SDD module child fields and STP fixtures
- Add `StpFixture` to `COVERED_TYPE_KEYS` for coverage-badge propagation
- 7 new unit tests pinning LLR-FRM-14 and LLR-PSP-10

### Dependencies
- Pin `undici` override to `^6.21.1`; npm audit now reports 0 vulnerabilities

### Docs
- SDP: add Phase 14 to Status table, §8 Phased Delivery, §10 estimates
- SAR: refresh §5 A06 (Mitigated), §6 findings (Bandit 30→7, ESLint 49→48 with 0 errors, Semgrep 44→31), §7 dependency counts
- VR: move 10 previously-dismissed npm advisories to §7 Resolved; bump to v0.3

## Checklist
- [x] SDP updated (Phase 14 added)
- [x] Static analysis run (`make -C tools analyze`)
- [x] SAR updated (§5, §6, §7)
- [x] Dependabot triaged (0 open alerts — nothing to dismiss)
- [x] VR updated (§2, §6, §7)
- [x] New unit tests added and trace-annotated in `doc/Project.xml`

Closes #48
