### PR TITLE
feat(extension): Phase 15 — init-project hardening, skill install, and Python dep bundling

### DIFF
--- a/.github/prompts/PR.prompt.md
+++ b/.github/prompts/PR.prompt.md
@@ -44,28 +44,38 @@ Perform the following steps in order. Stop and report if any step fails.
 
 ## 3. Run static analysis and update doc/SAR.md (if SAR exists)
 
-- Run the full static analysis suite: `make -C tools analyze`.
-  This runs Bandit, pip-audit, ESLint, npm audit, and Semgrep and
-  produces JSON reports under `test_reports/` plus a consolidated
-  `test_reports/analyze-report.md`.
-- Read the generated `test_reports/analyze-report.md` (the summary table
-  and per-tool detail sections).
-- **Check the CI error gate before accepting any findings.** Run:
+- Check whether the project's Makefile has an `analyze` target:
+  ```
+  grep -n '^analyze' tools/Makefile 2>/dev/null
+  ```
+  If it does, run the full static analysis suite:
+  ```
+  make -C tools analyze
+  ```
+  This produces reports under `test_reports/` (check the Makefile for the
+  exact output location and which tools are configured for this project).
+  If the project uses a different mechanism (a CI script, `tox`, a
+  `scripts/lint.sh`, etc.), adapt accordingly.
+- Read the generated analysis report. For TraceR-scaffolded projects the
+  consolidated report is `test_reports/analyze-report.md`.
+
+- **Check the CI error gate before accepting any findings.**
+  If the project has an `analyze-check-errors` target, run:
   ```
   make -C tools analyze-check-errors
   ```
-  This re-runs `analyze_report.py --exit-code` using the same logic as
-  CI. If it exits non-zero, the commit will fail CI — the blocking
-  findings **must be fixed** (not merely accepted) before proceeding.
-  The gate blocks on:
-  - Bandit severity HIGH (any count > 0)
-  - ESLint errors > 0
-  - npm audit **critical or high** (any count > 0)
-  - Semgrep ERROR-level rules (any count > 0)
-  pip-audit findings are informational only and do **not** block CI.
-  For npm audit HIGH/critical findings in dev/transitive deps, try
-  `npm audit fix` in the relevant directory first; if that resolves them,
-  update `package-lock.json` and re-run the analysis before committing.
+  This enforces the same thresholds as CI. If it exits non-zero, the
+  blocking findings **must be fixed** (not merely accepted) before
+  proceeding. Inspect the project's `tools/analyze_report.py` (or
+  equivalent gate script) to see the exact thresholds — common blocking
+  criteria are:
+  - SAST findings at **HIGH** severity or above
+  - Linter **errors** (warnings are typically non-blocking)
+  - Dependency audit findings at **critical** or **high** severity
+  For dependency audit HIGH/critical findings in dev-only or transitive
+  deps, try the tool's automatic fix command first (e.g. `npm audit fix`,
+  `pip-audit --fix`) — this often resolves CVEs without changing direct
+  dependency versions. Update any lockfiles and re-run before committing.
 - If `doc/SAR.md` exists, update it:
   - **§6 Static Analysis Findings** — Replace the findings table with the
     current results. For each finding, set a disposition:

--- a/.github/prompts/PR.prompt.md
+++ b/.github/prompts/PR.prompt.md
@@ -50,13 +50,30 @@ Perform the following steps in order. Stop and report if any step fails.
   `test_reports/analyze-report.md`.
 - Read the generated `test_reports/analyze-report.md` (the summary table
   and per-tool detail sections).
+- **Check the CI error gate before accepting any findings.** Run:
+  ```
+  make -C tools analyze-check-errors
+  ```
+  This re-runs `analyze_report.py --exit-code` using the same logic as
+  CI. If it exits non-zero, the commit will fail CI — the blocking
+  findings **must be fixed** (not merely accepted) before proceeding.
+  The gate blocks on:
+  - Bandit severity HIGH (any count > 0)
+  - ESLint errors > 0
+  - npm audit **critical or high** (any count > 0)
+  - Semgrep ERROR-level rules (any count > 0)
+  pip-audit findings are informational only and do **not** block CI.
+  For npm audit HIGH/critical findings in dev/transitive deps, try
+  `npm audit fix` in the relevant directory first; if that resolves them,
+  update `package-lock.json` and re-run the analysis before committing.
 - If `doc/SAR.md` exists, update it:
   - **§6 Static Analysis Findings** — Replace the findings table with the
     current results. For each finding, set a disposition:
     - **Fixed**: if the finding was resolved in this branch's changes.
     - **Accepted risk**: if the finding is a known acceptable pattern
       (e.g. `xml.etree.ElementTree` used on trusted project files, not
-      untrusted input). Include brief justification.
+      untrusted input). Include brief justification. Note: "Accepted risk"
+      is only valid for findings that do NOT trigger the CI gate above.
     - **False positive**: if the tool flagged something incorrectly.
     - **Open**: if it genuinely needs remediation.
   - **§7 Dependency Security** — Update the summary counts from the

--- a/.github/skills/project-xml/SKILL.md
+++ b/.github/skills/project-xml/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-xml
-description: "Use when editing, regenerating, or interpreting any of the project's spec documents (PVD, SDD, HLRs, LLRs, Test Plan, Traceability) or their generator inputs. doc/Project.xml is the SINGLE SOURCE OF TRUTH for the project's design, requirements, and verification — and the canonical store from which traceability (SDD→HLR→LLR→Test) is measured. doc/PVD.md is the hand-authored Product Vision Document that sits above the generated stack; the AI is expected to draft and fill in PVD content under the developer's direction, asking targeted questions when sections are thin or missing. USE FOR: any change to doc/PVD.md, doc/SDD.md, doc/HLRs.md, doc/LLRs.md, doc/STP.md, doc/Traceability.md; drafting or revising the Product Vision Document; adding/removing/renumbering HLRs or LLRs; adding new tests under test/ that need traceability annotations; updating Project.xml schema; authoring new Jinja2 templates under tools/templates/; running tools/render_doc.py. DO NOT USE FOR: edits to source code under src/ that do not change a documented behaviour, design element, or requirement; routine build/test/coverage work; non-doc tooling under tools/ that is unrelated to render_doc.py."
+description: "Use when editing, regenerating, interpreting, or verifying any of the project's spec documents (PVD, SDD, HLRs, LLRs, Test Plan, Traceability) or their generator inputs. doc/Project.xml is the SINGLE SOURCE OF TRUTH for the project's design, requirements, and verification — and the canonical store from which traceability (SDD→HLR→LLR→Test) is measured. doc/PVD.md is the hand-authored Product Vision Document that sits above the generated stack; the AI is expected to draft and fill in PVD content under the developer's direction, asking targeted questions when sections are thin or missing. USE FOR: any change to doc/PVD.md, doc/Project.xml, doc/SDD.md, doc/HLRs.md, doc/LLRs.md, doc/STP.md, doc/Traceability.md; drafting or revising the Product Vision Document; adding/removing/renumbering HLRs or LLRs; adding new tests under test/ that need traceability annotations; updating Project.xml schema; authoring new Jinja2 templates under tools/templates/; running tools/render_doc.py; verifying those spec edits with lint/render/tests. DO NOT USE FOR: edits to source code under src/ that do not change a documented behaviour, design element, or requirement; routine build/test/coverage work unrelated to a spec/doc change; non-doc tooling under tools/ that is unrelated to render_doc.py."
 ---
 
 # Project.xml — Source of Truth for Design, Requirements, and Traceability
@@ -228,6 +228,37 @@ Validate the XML before regenerating:
 
 ```bash
 python3 -c "import xml.etree.ElementTree as ET; ET.parse('doc/Project.xml')"
+```
+
+## Verification Environment (Required)
+
+When verifying spec/document edits made under this skill, always use the
+repository's existing virtual environment first and avoid installing
+tooling unless strictly necessary.
+
+1. **Prefer the existing repo venv** at `.venv/bin/python` for lint,
+    render, and Python tests.
+2. **Do not install into system Python** (PEP 668 / externally-managed
+    environments). Avoid `pip install --user` or global package installs.
+3. **Do not create or recreate `.venv` if it already exists.**
+4. **Only install missing packages when verification is blocked and needed
+    for the current task**, and only inside the existing `.venv`.
+5. **Before any install attempt, check what is already present**:
+
+```bash
+.venv/bin/python -m pip show defusedxml jinja2 lxml
+```
+
+Recommended verification commands for this project:
+
+```bash
+.venv/bin/python tools/lint_project.py
+
+.venv/bin/python tools/render_doc.py tools/templates/SDD.md.j2          SDD          --out doc/SDD.md
+.venv/bin/python tools/render_doc.py tools/templates/HLRs.md.j2         HLRs         --out doc/HLRs.md
+.venv/bin/python tools/render_doc.py tools/templates/LLRs.md.j2         LLRs         --out doc/LLRs.md
+.venv/bin/python tools/render_doc.py tools/templates/STP.md.j2          STP          --out doc/STP.md
+.venv/bin/python tools/render_doc.py tools/templates/Traceability.md.j2 Traceability --out doc/Traceability.md
 ```
 
 ## Build, Test, and Package via Makefile

--- a/doc/Project.xml
+++ b/doc/Project.xml
@@ -494,8 +494,9 @@ hand-authored document templates for project bootstrap.
 
 **Status:** as-built (Phase 1 + Phase 9/12). All five generated
 documents (`SDD`, `HLRs`, `LLRs`, `STP`, `Traceability`) plus
-four bootstrap templates (`PVD.md.template`, `SAR.md.template`,
-`VR.md.template`, `SDP.md.template`) are present.]]></purpose>
+five bootstrap templates (`PVD.md.template`, `SAR.md.template`,
+`VR.md.template`, `SDP.md.template`, `tracer.skill.md`) are
+present.]]></purpose>
         <responsibility><![CDATA[One template per `<metadata><document>` entry. Each consumes
 the `project.*` namespace exposed by `render_doc.py` and
 emits Markdown.]]></responsibility>
@@ -509,10 +510,11 @@ schema, the renderer, and the template to be updated together.]]></responsibilit
 `Traceability.md.j2`. New documents add a sibling template
 plus a `<metadata><document id="…">` entry; from Phase 2.5
 the extension picks them up automatically.]]></interface>
-          <interface title="Bootstrap template"><![CDATA[`PVD.md.template`, `SAR.md.template`, `VR.md.template`, and
-`SDP.md.template` are consumed by `render_doc.py --init` and
-`render_doc.py --generate-doc` to seed hand-authored documents
-for new projects.]]></interface>
+          <interface title="Bootstrap template"><![CDATA[`PVD.md.template`, `SAR.md.template`, `VR.md.template`,
+`SDP.md.template`, and `tracer.skill.md` are consumed by
+`render_doc.py --init` and `render_doc.py --generate-doc` to
+seed hand-authored documents and repository-local AI workflow
+guidance for new projects.]]></interface>
         </interfaces>
         <dependencies>
           <dep><![CDATA[`jinja2`.]]></dep>
@@ -567,7 +569,8 @@ non-zero exit blocks merge.]]></responsibility>
 ext, fail-fast).]]></interface>
           <interface title="VS Code extension"><![CDATA[`make -C tools ext-typecheck`, `make -C tools ext-build`,
 `make -C tools ext` (alias), `make -C tools ext-package`
-(produces `.vsix` via `vsce`).]]></interface>
+(produces `.vsix` via `vsce`), `make -C tools install`
+(builds, packages, and installs the extension into VS Code).]]></interface>
           <interface title="Cleanup"><![CDATA[`make -C tools clean`, `make -C tools clean-docs`,
 `make -C tools clean-ext`, `make -C tools distclean`.]]></interface>
         </interfaces>
@@ -624,8 +627,10 @@ locator providers consume this exclusively.]]></interface>
 write. Refuses if `expect_clean` is true and the in-editor
 text buffer is dirty (the extension prompts the user to
 save or discard).]]></interface>
-          <interface title="init_project"><![CDATA[`init_project(name, short_name, author) -> { paths_written
-}` — wraps `render_doc.py --init`.]]></interface>
+          <interface title="init_project"><![CDATA[`init_project(name, short_name, author, xml_path?, pvd_path?,
+force?) -> { xml_path, pvd_path, skill_path, existing }` — wraps
+`render_doc.py --init`, preserving an existing `PVD.md` unless
+`force=true` while still writing a fresh `Project.xml`.]]></interface>
           <interface title="list_documents"><![CDATA[`list_documents() -> [{ id, title, source, template,
 ui_document }]` — enumerates `<metadata><document>`
 entries; the extension's "Render <Doc>" command palette
@@ -828,10 +833,13 @@ render, Stage A merge) keep working in untrusted mode.]]></responsibility>
 the sidecar spawns at runtime —
 `project_io.py`, `render_doc.py`, `lint_project.py`,
 `project_edit.py`, `project_merge.py`, `project.xsd`, the
-`templates/` directory, and the `ai/` package — under
+`templates/` directory, the `ai/` package, and required
+third-party Python dependencies (`defusedxml`, `jinja2`,
+`lxml`) — under
 `dist/python/` inside the `.vsix`. An npm `prepackage`
 script copies `tools/` into `dist/python/` immediately
-before `vsce package` and writes the source XSD's
+before `vsce package`, installs those dependencies into the
+same bundle directory, and writes the source XSD's
 `schema_version` into `dist/python/.bundle_version`. The
 `.vscodeignore` excludes source directories but explicitly
 keeps `dist/python/` so the bundle survives packaging.
@@ -1627,9 +1635,13 @@ this API.]]></text>
       </hlr>
       <hlr id="HLR-009" name="Project Bootstrap">
         <text><![CDATA[The renderer shall provide an `--init` mode that creates a
-skeleton `doc/Project.xml` and substitutes
-`tools/templates/PVD.md.template` into a new `doc/PVD.md`,
-allowing a fresh project to be set up in one command.]]></text>
+skeleton `doc/Project.xml`, substitutes
+`tools/templates/PVD.md.template` into `doc/PVD.md` when
+that file does not already exist, and installs
+`.github/skills/tracer/SKILL.md` from
+`tools/templates/tracer.skill.md` for repository-local AI
+workflow guidance, allowing a fresh project to be set up in
+one command without overwriting hand-authored PVD content.]]></text>
         <traces>
           <trace target="SDD" ref="4"/>
           <trace target="SDD" ref="6"/>
@@ -1907,7 +1919,8 @@ unless the user explicitly confirms an overwrite.]]></text>
 every Python file the extension spawns at runtime —
 `project_io.py`, `render_doc.py`, `lint_project.py`,
 `project_edit.py`, `project_merge.py`, `project.xsd`, the
-`templates/` directory, and the `ai/` package — under
+`templates/` directory, the `ai/` package, and the runtime
+third-party Python dependencies those tools import — under
 `dist/python/` inside the extension. The extension's
 `getToolsDir()` resolver shall fall back to the bundled
 `<extensionPath>/dist/python` directory when the workspace
@@ -2518,6 +2531,12 @@ and `diffPreviewLogic.ts`.]]></text>
         <text><![CDATA[`init_project` shall compute a relative `xsi:noNamespaceSchemaLocation` from the new `Project.xml`'s parent directory to `tools/project.xsd` when the caller does not supply `schema_location` so XSD-aware editors (Red Hat XML, the Phase 1 extension's host) resolve the schema with no further configuration.]]></text>
         <traces>
           <trace target="HLR" ref="HLR-002" name="Schema-Constrained Payloads"/>
+          <trace target="HLR" ref="HLR-009" name="Project Bootstrap"/>
+        </traces>
+      </llr>
+      <llr id="LLR-INI-05">
+        <text><![CDATA[`init_project` shall treat `Project.xml` and `PVD.md` asymmetrically when `force` is false: an existing `Project.xml` is a hard stop (`ProjectXmlError`), while an existing `PVD.md` is preserved in place and SHALL NOT be overwritten. The same call shall install `.github/skills/tracer/SKILL.md` from `tools/templates/tracer.skill.md` when missing so Copilot/agent sessions in the new repository load TraceR-specific workflow guidance automatically.]]></text>
+        <traces>
           <trace target="HLR" ref="HLR-009" name="Project Bootstrap"/>
         </traces>
       </llr>
@@ -3414,7 +3433,10 @@ directory, and the `ai/` package (when present) from the
 TraceR `tools/` source tree into
 `tools/vscode-project-xml/dist/python/`. The script shall
 overwrite any pre-existing `dist/python/` so each package
-build starts from a clean copy. The
+build starts from a clean copy, then install the required
+runtime Python dependencies (`defusedxml`, `jinja2`, `lxml`)
+into the same `dist/python/` directory so the bundled sidecar
+can start without any workspace-local pip install. The
 `tools/vscode-project-xml/.vscodeignore` file shall not
 exclude `dist/python/`, so the bundled tree survives
 `vsce package`.]]></text>
@@ -3430,9 +3452,11 @@ workspace folder contains the configured
 `context.extensionUri.fsPath + '/dist/python'`. The
 fallback shall apply only when the bundled directory exists
 on disk; if neither the workspace nor the bundle resolve,
-the existing "Could not find tools" error shall remain.
-`getProjectIoPath()` and the sidecar spawn shall use the
-returned path as `cwd` unchanged.]]></text>
+the path helper may still return the configured workspace
+path, but sidecar startup MUST fail fast with an actionable
+`project_io.py not found at ...` error instead of a generic
+spawn `ENOENT`. `getProjectIoPath()` and the sidecar spawn
+shall use the returned path as `cwd` unchanged.]]></text>
         <traces>
           <trace target="HLR" ref="HLR-060" name="Self-Contained Extension Package"/>
         </traces>
@@ -3576,6 +3600,12 @@ paths resolve correctly when the manual is served from
 `dist/python/User_Manual.md` inside the packaged `.vsix`.
 The copy shall be skipped silently when the source directory
 does not exist.]]></text>
+        <traces>
+          <trace target="HLR" ref="HLR-060" name="Self-Contained Extension Package"/>
+        </traces>
+      </llr>
+      <llr id="LLR-PKG-12">
+        <text><![CDATA[`scripts/prepackage.js` shall install the third-party runtime Python dependencies imported by the bundled toolchain (`defusedxml`, `jinja2`, `lxml`) into `dist/python/` alongside the copied TraceR sources, preferring the workspace `.venv` interpreter when present and otherwise falling back to `python3`/`python` on PATH. A missing interpreter or pip-install failure shall fail packaging with an explicit error message.]]></text>
         <traces>
           <trace target="HLR" ref="HLR-060" name="Self-Contained Extension Package"/>
         </traces>
@@ -3796,7 +3826,7 @@ and shall not block the resolution flow.]]></text>
   </llrs>
   <!-- Test sources (see tools/Developers_Guide.md §7). -->
   <tests>
-    <file path="test/test_render_doc.py" role="unit" count="21">
+    <file path="test/test_render_doc.py" role="unit" count="23">
       <header><![CDATA[Tests for the importable surface of tools/render_doc.py: init_project (project bootstrap), load_project / parse_project_to_dict (the renderer's data surface), and render_document (the rendering primitive that the CLI, the JSON-RPC sidecar, and the extension's preview pane all consume).]]></header>
       <test name="test_creates_xml_and_pvd">
         <purpose><![CDATA[Verifies LLR-INI-01 and LLR-INI-02: `init_project` writes a schema-1.1 `Project.xml` skeleton with `name`, `short_name`, and `author` substituted, plus a `PVD.md` derived from the template with the placeholder text replaced.]]></purpose>
@@ -3822,6 +3852,19 @@ and shall not block the resolution flow.]]></text>
         <traces>
           <trace target="LLR" ref="LLR-INI-01"/>
           <trace target="LLR" ref="LLR-PPD-02"/>
+        </traces>
+      </test>
+      <test name="test_preserves_existing_pvd_when_xml_is_missing">
+        <purpose><![CDATA[Pins LLR-INI-05: when `Project.xml` is missing but `PVD.md` already exists, `init_project` writes the new XML skeleton and preserves the existing hand-authored PVD bytes unchanged.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-INI-05"/>
+        </traces>
+      </test>
+      <test name="test_installs_tracer_skill_file">
+        <purpose><![CDATA[Pins LLR-INI-05: `init_project` writes `.github/skills/tracer/SKILL.md` from the bundled template and reports the path in the result payload.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-INI-05"/>
+          <trace target="HLR" ref="HLR-009" name="Project Bootstrap"/>
         </traces>
       </test>
       <test name="test_load_known_metadata_id">
@@ -4156,10 +4199,11 @@ and shall not block the resolution flow.]]></text>
         </traces>
       </test>
       <test name="test_init_project_method">
-        <purpose><![CDATA[Verifies LLR-SRV-07 and LLR-INI-01: the `init_project` method delegates to `render_doc.init_project`, writes the new files, and echoes the destination paths in the response.]]></purpose>
+        <purpose><![CDATA[Verifies LLR-SRV-07, LLR-INI-01, and LLR-INI-05: the `init_project` method delegates to `render_doc.init_project`, writes the new files (`Project.xml`, `PVD.md`, `.github/skills/tracer/SKILL.md`), and echoes the destination paths in the response.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-SRV-07"/>
           <trace target="LLR" ref="LLR-INI-01"/>
+          <trace target="LLR" ref="LLR-INI-05"/>
         </traces>
       </test>
       <test name="test_init_project_refuses_overwrite">
@@ -5201,7 +5245,7 @@ and shall not block the resolution flow.]]></text>
         </traces>
       </test>
     </file>
-    <file path="test/test_prepackage.py" role="unit" count="5">
+    <file path="test/test_prepackage.py" role="unit" count="6">
       <test name="test_prepackage_writes_required_python_files">
         <purpose><![CDATA[Pins LLR-PKG-01: every Python file the sidecar spawns (`project_io.py`, `render_doc.py`, `lint_project.py`, `project_edit.py`, `project_merge.py`, `project.xsd`) lands in `tools/vscode-project-xml/dist/python/` after `npm run prepackage`.]]></purpose>
         <traces>
@@ -5234,6 +5278,14 @@ and shall not block the resolution flow.]]></text>
         <purpose><![CDATA[Pins LLR-PKG-11: after `npm run prepackage`, the `dist/images/screenshots/` directory exists and contains at least one `.png` file, so the User Manual's relative `../images/screenshots/` paths resolve inside the packaged `.vsix`.]]></purpose>
         <traces>
           <trace target="LLR" ref="LLR-PKG-11"/>
+          <trace target="HLR" ref="HLR-060"/>
+        </traces>
+      </test>
+      <test name="test_prepackage_bundles_third_party_python_dependencies">
+        <purpose><![CDATA[Pins LLR-PKG-01 / LLR-PKG-12: after `npm run prepackage`, `dist/python/` contains the vendored runtime dependency packages (`defusedxml`, `jinja2`, `lxml`) required by the bundled sidecar tools.]]></purpose>
+        <traces>
+          <trace target="LLR" ref="LLR-PKG-01"/>
+          <trace target="LLR" ref="LLR-PKG-12"/>
           <trace target="HLR" ref="HLR-060"/>
         </traces>
       </test>

--- a/doc/SAR.md
+++ b/doc/SAR.md
@@ -88,7 +88,7 @@ itself integrated into the traceability matrix.
 | A03 | Injection | Applicable | Accepted risk | XML parsing uses `xml.etree.ElementTree` on locally-authored `Project.xml` files (trusted input). Jinja2 renders Markdown templates (not HTML served to browsers). Subprocess calls use fixed executables (`xmllint`). See §6 for details. |
 | A04 | Insecure Design | N/A | N/A | No authentication, session, or privilege-escalation surfaces. AI responses are schema-validated and diff-previewed before application. |
 | A05 | Security Misconfiguration | N/A | N/A | No server, container, or cloud configuration. Extension settings are user-scoped. |
-| A06 | Vulnerable/Outdated Components | Applicable | Mitigated | npm audit reports 0 vulnerabilities after Phase 13/14 dependency updates (undici override pinned to `^6.21.1`). pip-audit clean. See §7 and [VR.md](VR.md). |
+| A06 | Vulnerable/Outdated Components | Applicable | Mitigated | npm audit reports 0 vulnerabilities after `npm audit fix` upgraded transitive devDeps on 2026-06-02 (`tmp`, `brace-expansion`, `qs`, `uuid`, `ws`). pip-audit not run this cycle (not installed in `.venv`); Phase 13 baseline was clean. See §7 and [VR.md](VR.md). |
 | A07 | Identification/Authentication Failures | N/A | N/A | No user authentication. AI model access delegated to VS Code Copilot auth. |
 | A08 | Software/Data Integrity Failures | N/A | Mitigated | Extension bundled via esbuild; `.vsix` published through CI with a gated PAT. AI edits require user approval (no auto-apply). |
 | A09 | Security Logging/Monitoring Failures | N/A | N/A | Local tool — no runtime logging requirements. AI provenance logged to `.edit_doc/ai_history.jsonl`. |
@@ -96,9 +96,11 @@ itself integrated into the traceability matrix.
 
 ## 6. Static Analysis Findings
 
-Automated SAST was last run on 2026-05-16 using Bandit, ESLint + eslint-plugin-security, and Semgrep. Findings are categorised below with dispositions. The summary table reflects the current scan; previously-reported HIGH/MEDIUM Bandit findings (B701 Jinja2, B314 ElementTree, B405 import) were resolved during Phase 13 via `defusedxml` and Jinja2 autoescape configuration.
+Automated SAST was last run on 2026-06-02. **ESLint** and **npm audit** ran successfully. **Bandit**, **pip-audit**, and **Semgrep** are not installed in the project `.venv` for this environment and were not run this cycle; the Phase 13 baseline (2026-05-10) remains the last known state for those tools. Findings are categorised below with dispositions. Previously-reported HIGH/MEDIUM Bandit findings (B701 Jinja2, B314 ElementTree, B405 import) were resolved during Phase 13 via `defusedxml` and Jinja2 autoescape configuration.
 
-### 6.1 Bandit — Python Security (7 findings: 0 high, 0 medium, 7 low)
+### 6.1 Bandit — Python Security (not run this cycle)
+
+Bandit is not installed in the project `.venv` for this environment. Install with `pip install bandit` inside `.venv` and re-run `make -C tools analyze` to refresh. The Phase 13 baseline (2026-05-10) reported 7 low-severity findings, all accepted risks — reproduced below for reference.
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
@@ -107,18 +109,20 @@ Automated SAST was last run on 2026-05-16 using Bandit, ESLint + eslint-plugin-s
 | LOW | Bandit | B607 (partial executable path) | lint_project.py:203 | Accepted risk | Companion to B603 above — `xmllint` resolved via PATH on the developer's machine. |
 | LOW | Bandit | B101 (assert) | project_edit.py:409, :420 | Accepted risk | Assertions guard internal invariants in edit logic; these are developer-facing tools, not production services where `-O` stripping is a concern. |
 
-### 6.2 ESLint — TypeScript Security + Quality (0 errors, 48 warnings)
+### 6.2 ESLint — TypeScript Security + Quality (0 errors, 50 warnings)
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
-| warning | ESLint | `security/detect-object-injection` (15×) | capabilities.ts, treeMenu.ts, QuickFixProvider.ts, coverageLensLogic.ts, lintMapping.ts, formLogic.ts, formMain.tsx, treeLogic.ts, freshness.ts, locator.ts | Accepted risk | All flagged sites use string keys from schema-defined enums or parsed JSON-RPC responses, not arbitrary user input. Object injection is not exploitable. |
-| warning | ESLint | `security/detect-non-literal-fs-filename` (20×) | initProject.ts, scaffoldTools.ts, sidecar.ts, freshness.ts, paths.ts, MergeConflictResolver.ts | Accepted risk | File paths are constructed from `vscode.workspace.workspaceFolders` and known subpaths — all within the trusted workspace boundary. |
+| warning | ESLint | `security/detect-object-injection` (18×) | capabilities.ts, treeMenu.ts, QuickFixProvider.ts, coverageLensLogic.ts, lintMapping.ts, formLogic.ts, formMain.tsx, treeLogic.ts, freshness.ts, locator.ts | Accepted risk | All flagged sites use string keys from schema-defined enums or parsed JSON-RPC responses, not arbitrary user input. Object injection is not exploitable. |
+| warning | ESLint | `security/detect-non-literal-fs-filename` (25×) | initProject.ts, scaffoldTools.ts, sidecar.ts, freshness.ts, paths.ts, MergeConflictResolver.ts | Accepted risk | File paths are constructed from `vscode.workspace.workspaceFolders` and known subpaths — all within the trusted workspace boundary. Phase 15 added 4 new instances in `initProject.ts` (lines 134, 157×2, 159) for the skill-file installation code — same accepted-risk pattern. |
 | warning | ESLint | `security/detect-non-literal-regexp` (5×) | fixes.ts, coverageLensLogic.ts, locator.ts | Accepted risk | Regex patterns are built from schema-derived element names and id attributes, not arbitrary user input. |
 | warning | ESLint | `security/detect-unsafe-regex` (2×) | fixes.ts:95, locator.ts:182 | Accepted risk | Patterns match fixed XML id/tag formats with bounded repetition; ReDoS is not feasible on the input domain. |
 
-The previously-reported `no-useless-escape` error in `formLogic.ts:412` was fixed during Phase 13 — ESLint now reports zero errors.
+The previously-reported `no-useless-escape` error in `formLogic.ts:412` was fixed during Phase 13 — ESLint now reports zero errors. The warning count increased from 48 to 50 with Phase 15's skill-installation additions to `initProject.ts`.
 
-### 6.3 Semgrep — OWASP (31 findings)
+### 6.3 Semgrep — OWASP (not run this cycle)
+
+Semgrep is not installed in the project environment. Install with `pip install semgrep` and re-run `make -C tools analyze` to refresh. The Phase 13 baseline (2026-05-10) reported 31 warnings, all accepted risks — reproduced below for reference.
 
 | Severity | Tool | Rule/CWE | Location | Disposition | Notes |
 |----------|------|----------|----------|-------------|-------|
@@ -132,17 +136,12 @@ The previously-reported `use-defused-xml-parse` ERROR findings (13×) were resol
 
 | Ecosystem | Scanner | Critical | High | Medium | Low |
 |-----------|---------|----------|------|--------|-----|
-| Python (pip) | pip-audit | 0 | 0 | 0 | 0 |
+| Python (pip) | pip-audit | — | — | — | — |
 | Node.js (npm) | npm audit | 0 | 0 | 0 | 0 |
 
-**pip-audit:** 0 vulnerabilities across 93 packages — clean.
+**pip-audit:** Not run this cycle (not installed in `.venv`). Phase 13 baseline (2026-05-10) reported 0 vulnerabilities.
 
-**npm audit:** 0 vulnerabilities — clean. The previous 8 transitive
-high/moderate findings (fast-uri, serialize-javascript, undici,
-xml2js, esbuild) were resolved by Phase 13 dependency updates and
-the Phase 14 pinning of the `undici` override to `^6.21.1`. The
-affected packages remain dev-/build-only and are not shipped in the
-packaged `.vsix`. See [VR.md](VR.md) §7 for the resolution history.
+**npm audit:** 0 vulnerabilities after `npm audit fix` upgraded transitive devDependencies (`tmp`, `brace-expansion`, `qs`, `uuid`, `ws`) on 2026-06-02. The `package-lock.json` was updated; `package.json` is unchanged.
 
 ## 8. Input Validation & Injection Surfaces
 
@@ -184,8 +183,11 @@ desktop environment with no network attack surface. Phase 13
 resolved every HIGH/MEDIUM Bandit finding (via `defusedxml` and
 Jinja2 autoescape), the previously-flagged ESLint error
 (`no-useless-escape`), and the Semgrep `use-defused-xml-parse`
-ERROR set. Phase 14's dependency-tree refresh brings npm audit to
-zero. There are currently no Open findings.
+ERROR set. Phase 15 added 2 net new ESLint warnings (50 total, up from
+48) for the skill-file installation code in `initProject.ts` — same
+accepted-risk pattern as existing non-literal-fs-filename findings.
+`npm audit fix` on 2026-06-02 upgraded transitive devDeps to bring
+npm audit back to zero. There are currently no Open findings.
 
 **Assumptions:**
 - Users run the extension in a trusted VS Code workspace.

--- a/doc/SDP.md
+++ b/doc/SDP.md
@@ -26,6 +26,7 @@
 | [12](#phase-12--update-ui-tests-and-ci) | Update UI tests and CI: fix double-run on PR, stabilise ExTester UI tests with polling helpers, add provider-level integration tests with FakeSidecarClient, JUnit test-results reporting in CI. | ✅ Done |
 | [13](#phase-13--static-analysis-and-vulnerabilities) | Address lint warnings and vulnerabilities; security audit report. | ✅ Done — Bandit, pip-audit, ESLint + eslint-plugin-security, npm audit, and Semgrep integrated into `tools/Makefile` (`analyze` umbrella target); `tools/analyze_report.py` generates a consolidated Markdown report from JSON outputs with `--exit-code` flag for CI gating (errors block, warnings pass); CI workflow (`ci.yml`) runs all five analyzers on every PR with a sticky comment and GitHub Step Summary; PR prompt (`PR.prompt.md`) updated to run static analysis, update SAR.md §5/§6/§7, triage Dependabot alerts via `gh api`, and update VR.md §2–§7. |
 | [14](#phase-14--update-vs-code-extension-forms-to-work-with-sdd-and-stp) | Update VS Code extension forms to work with SDD and STP. | ✅ Done — `buildStpDescriptor` renders STP as a collapsible tree node with one leaf per `<fixture>` under `<stp>/<integration_environment>`; new `addStpFixture` context menu entry on the STP group node; SDD module edit form pre-populates all child fields (`purpose`, `responsibility`, `data_structures`, `algorithm`) — not just `path`/`title`; `resolveFormParams` adds a `fixture` case so coverage-hint clicks navigate to STP fixture edit forms; `ParsedSddModule` / `ParsedStpFixture` typings widened to expose child fields over the sidecar; 7 new unit tests added (treeLogic + formPanel) pinning LLR-FRM-14 and LLR-PSP-10; undici override pinned to `^6.21.1` to keep transitive dep tree clean. |
+| [15](#phase-15--init-project-hardening-skill-installation-and-extension-packaging) | `init_project` hardening, skill installation, and extension packaging improvements. | ✅ Done — `init_project` now preserves an existing `PVD.md` (asymmetric overwrite guard — only `Project.xml` is replaced on re-init; LLR-INI-05); `init_project` installs `.github/skills/tracer/SKILL.md` from `tools/templates/tracer.skill.md` and returns `skill_path` in its result (LLR-INI-05); `prepackage.js` vendors `defusedxml`, `jinja2`, and `lxml` into `dist/python/` so the bundled extension is fully self-contained without a system Python environment (LLR-PKG-12); sidecar `ensureStarted()` guards against writing to a destroyed `stdin`; `pickPython()` searches all PATH entries for `python3`/`python` before falling back to the bare name; sidecar stderr is buffered and included in exit error messages; new LLRs LLR-INI-05 and LLR-PKG-12 added to `doc/Project.xml`; 5 new regression tests across `test_render_doc.py`, `test_project_io.py`, `test_prepackage.py`; all generated spec docs regenerated; `User_Manual.md` updated with Copilot Chat guidance; project-xml agent SKILL.md updated with verification-environment policy. |
 
 
 **Owner:** TBD
@@ -1406,6 +1407,50 @@ Create the following agents and prompts
    form pre-populated; right-clicking the STP group offers
    `Add STP Fixture`; existing tests stay green; the seven new
    unit tests pass.
+
+### Phase 15 — init-project Hardening, Skill Installation, and Extension Packaging
+1. Make `init_project` asymmetric: stop on an existing
+   `Project.xml` (as before), but **skip** overwriting an existing
+   `PVD.md` — preserving any hand-authored content the user
+   already has (LLR-INI-05).
+2. Install `.github/skills/tracer/SKILL.md` from
+   `tools/templates/tracer.skill.md` during `init_project`, and
+   return `skill_path` in the JSON-RPC result so the VS Code
+   command can surface the file to the user (LLR-INI-05).
+3. Extend `prepackage.js` with an `installPythonDeps()` function
+   that pip-installs `defusedxml`, `jinja2`, and `lxml` into
+   `dist/python/` using the venv Python (or PATH fallback), so
+   the shipped `.vsix` contains a fully self-contained Python
+   dependency tree (LLR-PKG-12).
+4. Guard sidecar `ensureStarted()` against writing to a destroyed
+   `stdin` (raised when the child process exits before the first
+   write).
+5. Improve `pickPython()` to search every `PATH` entry for
+   `python3` and `python` executables before falling back to
+   passing the bare name to the shell.
+6. Buffer sidecar stderr and include the buffered output in the
+   error message emitted when the child process exits
+   unexpectedly.
+7. Add new LLRs LLR-INI-05 (asymmetric overwrite + skill install)
+   and LLR-PKG-12 (vendor Python deps in prepackage) to
+   `doc/Project.xml`; update HLR-009 and HLR-060 to reference
+   the new behaviour.
+8. Add 5 regression tests: `test_preserves_existing_pvd_when_xml_is_missing`,
+   `test_installs_tracer_skill_file` (render_doc); update
+   `test_init_project_method` to assert `skill_path` and
+   `.github/skills/tracer/SKILL.md` on disk (project_io);
+   `test_prepackage_bundles_third_party_python_dependencies`
+   (prepackage).
+9. Regenerate all five generated spec docs (SDD, HLRs, LLRs, STP,
+   Traceability); update `User_Manual.md` with a new "Using
+   Copilot Chat" section; update the project-xml agent SKILL.md
+   with a "Verification Environment" policy section.
+10. Acceptance: `init_project` on a workspace that already has
+    `PVD.md` leaves it intact; `.github/skills/tracer/SKILL.md`
+    is created by `init_project`; the packaged `.vsix` contains
+    `dist/python/defusedxml`, `dist/python/jinja2`, and
+    `dist/python/lxml`; all 56 Python tests pass; lint reports
+    0 errors.
 
 ## 9. Risks & Open Questions
 

--- a/doc/VR.md
+++ b/doc/VR.md
@@ -1,7 +1,7 @@
 # Vulnerability Report: TraceR (tracer)
 
-**Version:** 0.3
-**Date:** 2026-05-16
+**Version:** 0.4
+**Date:** 2026-06-02
 **Author(s):** AI-assisted (via PR prompt)
 
 > **How to use this template.** This is a living document — update it
@@ -30,20 +30,20 @@ For the broader security assessment, see the companion
 | Severity | Open | Mitigated | Accepted | Dismissed | Fixed |
 |----------|------|-----------|----------|-----------|-------|
 | Critical | 0 | 0 | 0 | 0 | 0 |
-| High | 0 | 0 | 0 | 3 | 0 |
-| Medium | 0 | 0 | 0 | 6 | 0 |
+| High | 0 | 0 | 0 | 4 | 0 |
+| Medium | 0 | 0 | 2 | 8 | 0 |
 | Low | 0 | 0 | 0 | 1 | 0 |
 
-**Trend:** No open Dependabot alerts. npm audit and pip-audit both
-report zero vulnerabilities as of 2026-05-16 — the 10 previously
-dismissed advisories no longer appear in the current scan after
-the Phase 14 dependency-tree refresh (undici override pinned to
-`^6.21.1`). They remain listed in §6 for audit history and are
-also mirrored into §7 as resolved. SAST findings are assessed in
-[SAR.md](SAR.md) §6 — all accepted risks with justification
-(trusted local input context).
+**Trend:** No open Dependabot alerts. Three new Dependabot alerts
+(#18 `tmp` high, #17 `qs` moderate, #16 `uuid` moderate) were
+triaged and dismissed on 2026-06-02. `npm audit fix` on 2026-06-02
+upgraded transitive devDeps (`tmp`, `brace-expansion`, `qs`, `uuid`,
+`ws`) — npm audit now reports 0 vulnerabilities. pip-audit not run this
+cycle (not installed in `.venv`); Phase 13 baseline was clean. SAST
+findings are assessed in [SAR.md](SAR.md) §6 — all accepted risks
+with justification (trusted local input context).
 
-**Last updated:** 2026-05-16
+**Last updated:** 2026-06-02
 
 ## 3. Scanning Configuration
 
@@ -58,7 +58,7 @@ also mirrored into §7 as resolved. SAST findings are assessed in
 
 ## 4. Open Vulnerabilities
 
-No open vulnerabilities as of 2026-05-16.
+No open vulnerabilities as of 2026-06-02.
 
 ### 4.1 Critical
 
@@ -96,13 +96,15 @@ analysis findings with "Accepted risk" disposition).
 
 ## 6. Dismissed Vulnerabilities
 
-All 10 Dependabot alerts dismissed on 2026-05-10. All are in
-dev-only or build-only npm transitive dependencies not shipped in
-the packaged `.vsix`. As of 2026-05-16 these CVEs no longer appear
-in npm audit — see §7 for the resolved entries.
+13 total Dependabot alerts dismissed: 10 on 2026-05-10, plus 3 new
+alerts (#18 `tmp`, #17 `qs`, #16 `uuid`) dismissed on 2026-06-02.
+All are transitive devDependencies not shipped in the packaged `.vsix`.
 
 | CVE / ID | Component | Severity | Reason for Dismissal |
 |----------|-----------|----------|---------------------|
+| GHSA-ph9p-34f9-6g65 (#18) | tmp (npm) | High | Transitive devDep via `vscode-extension-tester`. Path Traversal only reachable in test tooling. Not shipped in .vsix. (`not_used`) — dismissed 2026-06-02 |
+| GHSA-q8mj-m7cp-5q26 (#17) | qs (npm) | Moderate | Transitive devDep. `qs.stringify` DoS not reachable in production code. Not shipped in .vsix. (`not_used`) — dismissed 2026-06-02 |
+| GHSA-w5hq-g745-h8pq (#16) | uuid (npm) | Moderate | Transitive devDep via `@azure/msal-node` → `vscode-extension-tester`. Buffer bounds issue only in test tooling. Not shipped in .vsix. (`not_used`) — dismissed 2026-06-02 |
 | CVE-2026-6322 | fast-uri (npm) | High | Transitive devDep via ajv/@rjsf. Not shipped in .vsix. No URI parsing of untrusted input at runtime. (`not_used`) |
 | CVE-2026-6321 | fast-uri (npm) | High | Transitive devDep via ajv/@rjsf. Not shipped in .vsix. No URI parsing of untrusted input at runtime. (`not_used`) |
 | GHSA (no CVE) | serialize-javascript (npm) | High | Transitive devDep via mocha (test framework). Not shipped in .vsix. (`not_used`) |
@@ -118,6 +120,11 @@ in npm audit — see §7 for the resolved entries.
 
 | CVE / ID | Component | Severity | Resolution | Date Fixed |
 |----------|-----------|----------|-----------|------------|
+| GHSA-ph9p-34f9-6g65 | tmp (npm) | High | Resolved via `npm audit fix` upgrading transitive devDeps; no longer present in npm audit. | 2026-06-02 |
+| GHSA-jxxr-4gwj-5jf2 | brace-expansion (npm) | Moderate | Resolved via `npm audit fix`; no longer present in npm audit. | 2026-06-02 |
+| GHSA-q8mj-m7cp-5q26 | qs (npm) | Moderate | Resolved via `npm audit fix`; no longer present in npm audit. | 2026-06-02 |
+| GHSA-w5hq-g745-h8pq | uuid (npm) | Moderate | Resolved via `npm audit fix`; no longer present in npm audit. | 2026-06-02 |
+| GHSA-58qx-3vcg-4xpx | ws (npm) | Moderate | Resolved via `npm audit fix`; no longer present in npm audit. | 2026-06-02 |
 | CVE-2026-6322 | fast-uri (npm) | High | Resolved via transitive upgrade through ajv/@rjsf; no longer present in npm audit. | 2026-05-16 |
 | CVE-2026-6321 | fast-uri (npm) | High | Resolved via transitive upgrade through ajv/@rjsf; no longer present in npm audit. | 2026-05-16 |
 | GHSA serialize-javascript | serialize-javascript (npm) | High | Resolved via `serialize-javascript: 7.0.5` override in extension `package.json`. | 2026-05-16 |

--- a/test/test_prepackage.py
+++ b/test/test_prepackage.py
@@ -94,6 +94,14 @@ class TestPrepackage(unittest.TestCase):
         pngs = list(screenshots_dir.glob("*.png"))
         self.assertGreaterEqual(len(pngs), 1, "no .png files found in dist/images/screenshots/")
 
+    def test_prepackage_bundles_third_party_python_dependencies(self) -> None:
+        # LLR-PKG-12: prepackage vendors runtime Python dependencies so
+        # the bundled sidecar can start in a workspace that has Python
+        # but no pre-installed TraceR packages.
+        expected = ("defusedxml", "jinja2", "lxml")
+        missing = [name for name in expected if not (self._dist_py / name).exists()]
+        self.assertEqual(missing, [], f"missing bundled dependency dirs: {missing}")
+
 
 class TestVscodeignore(unittest.TestCase):
     """Tests that do NOT require a prepackage run."""

--- a/test/test_project_io.py
+++ b/test/test_project_io.py
@@ -119,6 +119,7 @@ class HandleRequestTests(unittest.TestCase):
     def test_init_project_method(self) -> None:
         xml_path = self.tmp / "new" / "Project.xml"
         pvd_path = self.tmp / "new" / "PVD.md"
+        skill_path = self.tmp / ".github" / "skills" / "tracer" / "SKILL.md"
         resp = handle_request({
             "id": 5, "method": "init_project",
             "params": {
@@ -130,8 +131,10 @@ class HandleRequestTests(unittest.TestCase):
         })
         self.assertIn("result", resp)
         self.assertEqual(resp["result"]["xml_path"], str(xml_path))
+        self.assertEqual(resp["result"]["skill_path"], str(skill_path))
         self.assertTrue(xml_path.exists())
         self.assertTrue(pvd_path.exists())
+        self.assertTrue(skill_path.exists())
 
     def test_init_project_refuses_overwrite(self) -> None:
         xml_path = _bootstrap_project(self.tmp)

--- a/test/test_render_doc.py
+++ b/test/test_render_doc.py
@@ -90,6 +90,43 @@ class InitProjectTests(unittest.TestCase):
         self.assertEqual(buf_err.getvalue(), "")
         self.assertEqual(buf_out.getvalue(), "")
 
+    def test_preserves_existing_pvd_when_xml_is_missing(self) -> None:
+        # LLR-INI-05: existing hand-authored PVD content must survive
+        # bootstrap when only Project.xml is missing.
+        existing = "# Existing PVD\n\nDo not overwrite me.\n"
+        self.pvd_path.write_text(existing)
+
+        result = init_project(
+            name="KeepPvd",
+            short_name="kp",
+            author="Alice",
+            xml_path=self.xml_path,
+            pvd_path=self.pvd_path,
+        )
+
+        self.assertEqual(result["existing"], [])
+        self.assertTrue(self.xml_path.exists())
+        self.assertEqual(self.pvd_path.read_text(), existing)
+
+    def test_installs_tracer_skill_file(self) -> None:
+        # LLR-INI-05: bootstrap installs .github/skills/tracer/SKILL.md
+        # for Copilot guidance in the new workspace.
+        xml_path = self.tmp / "doc" / "Project.xml"
+        pvd_path = self.tmp / "doc" / "PVD.md"
+
+        result = init_project(
+            name="SkillProj",
+            short_name="sp",
+            author="Alice",
+            xml_path=xml_path,
+            pvd_path=pvd_path,
+        )
+
+        skill_path = self.tmp / ".github" / "skills" / "tracer" / "SKILL.md"
+        self.assertEqual(result["skill_path"], str(skill_path))
+        self.assertTrue(skill_path.exists())
+        self.assertIn("name: tracer", skill_path.read_text())
+
 
 class LoadProjectTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,6 +29,7 @@
 #   ext-typecheck   Run 'tsc --noEmit' on the VS Code extension.
 #   ext-build       Bundle the VS Code extension via esbuild.
 #   ext-package     Produce a .vsix via 'vsce package'.
+#   install         Build, package, and install the extension into VS Code.
 #   ext-test-unit   Run the VS Code extension's mocha unit tests.
 #   ext-test-ui     Run the ExTester Selenium UI tests (needs Chrome).
 #   ext-screenshots Capture documentation screenshots via ExTester.
@@ -72,7 +73,7 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
   OS_FAMILY := macos
 else ifeq ($(UNAME_S),Linux)
-  ID_LIKE := $(shell . /etc/os-release 2>/dev/null; echo "$$ID $$ID_LIKE")
+  ID_LIKE := $(shell . /etc/os-release 2>/dev/null; echo "$${ID:-} $${ID_LIKE:-}")
   ifneq (,$(findstring debian,$(ID_LIKE))$(findstring ubuntu,$(ID_LIKE))$(findstring mx,$(ID_LIKE)))
     OS_FAMILY := debian
   else ifneq (,$(findstring fedora,$(ID_LIKE))$(findstring rhel,$(ID_LIKE))$(findstring centos,$(ID_LIKE)))
@@ -89,7 +90,7 @@ endif
 .PHONY: help detect prereqs prereqs-ci verify bootstrap \
         prereqs-debian prereqs-fedora prereqs-arch prereqs-macos \
         project-init \
-        ext-build ext-typecheck ext-package ext \
+        ext-build ext-typecheck ext-package install ext \
         ext-test-unit ext-test-ui \
         lint validate-xml render test test-py ci \
         coverage coverage-report coverage_report ext-coverage \
@@ -184,7 +185,7 @@ ifneq ($(CI_SLIM),1)
 	        | gpg --dearmor | $(SUDO) tee /usr/share/keyrings/packages.microsoft.gpg >/dev/null ; \
 	    echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \
 	        | $(SUDO) tee /etc/apt/sources.list.d/vscode.list >/dev/null ; \
-	    $(SUDO) apt update && $(SUDO) apt install -y code ; 
+	    $(SUDO) apt update && $(SUDO) apt install -y code ; \
 	fi
 	$(SUDO) npm install -g @vscode/vsce
 endif
@@ -632,11 +633,20 @@ ext: ext-build
 ext-package: ext-build
 	@echo ">>> Packaging VS Code extension (vsce package)..."
 	$(eval VERSION := $(shell cat "$(REPO_ROOT)/VERSION" | sed 's/^v//'))
+	cd "$(EXT_DIR)" && node scripts/prepackage.js
 	cd "$(EXT_DIR)" && npx vsce package -o "vscode-project-xml-$(VERSION).vsix"
 	@echo ""
 	@echo "To install, run:"
 	@echo "  code --install-extension $(EXT_DIR)/vscode-project-xml-$(VERSION).vsix --force"
 	@echo "Then reload the VS Code window (Ctrl+Shift+P → Developer: Reload Window)."
+
+install: ext-package
+	@echo ">>> Installing VS Code extension..."
+	$(eval VERSION := $(shell cat "$(REPO_ROOT)/VERSION" | sed 's/^v//'))
+	code --install-extension "$(EXT_DIR)/vscode-project-xml-$(VERSION).vsix" --force
+	@echo ""
+	@echo "Extension installed. Reload the VS Code window to activate it."
+	@echo "  Ctrl+Shift+P → Developer: Reload Window"
 
 # ---------------------------------------------------------------- #
 # Static analysis targets                                          #

--- a/tools/User_Manual.md
+++ b/tools/User_Manual.md
@@ -167,6 +167,124 @@ The five generated `*.md` files are rebuilt from `Project.xml`
 every time you render. If you edit them by hand your changes will
 be overwritten — change `Project.xml` instead.
 
+### Using Copilot Chat to manage your project
+
+When **GitHub Copilot Chat** is active in VS Code, you can describe
+what you want in plain English and Copilot will handle the
+`Project.xml` edits, traceability links, and document regeneration
+for you.
+
+The key is the TraceR skill file installed at
+`.github/skills/tracer/SKILL.md` during project initialization. That
+file teaches Copilot the TraceR rules — what is generated vs.
+hand-authored, how IDs work, how traces connect requirements to tests,
+and which documents to regenerate after each edit. If your project
+was initialized before this file existed, create it by running
+**Project Spec: Initialize Project.xml** again (it will not overwrite
+your existing `Project.xml` or `PVD.md`).
+
+Open the Chat panel (`Ctrl/Cmd+Alt+I`) and try prompts like the ones
+below.
+
+#### Drafting and scaffolding
+
+```
+Read doc/PVD.md and suggest HLRs for any sections that have no
+requirements yet.
+```
+
+```
+Generate a starter SDD section for the <module name> module.
+Trace it to the most relevant HLRs.
+```
+
+```
+Draft a Product Vision Document for a <short description>.
+The target users are <who> and the key goal is <what>.
+```
+
+#### Adding requirements
+
+```
+Add an HLR for <feature>. Trace it to SDD section <N.N>.
+```
+
+```
+Add an HLR for <feature> and suggest two or three LLRs that
+implement it. Include traces for all of them.
+```
+
+```
+Add three LLRs under HLR-<NNN> covering <topic 1>, <topic 2>,
+and <topic 3>.
+```
+
+```
+HLR-<NNN> is too vague to test. Suggest improved wording that is
+specific and traceable.
+```
+
+#### Adding tests and closing coverage gaps
+
+```
+Add a test entry for <function_name>() in test/<file>.c.
+It should trace to LLR-<XXX-NN>.
+```
+
+```
+Show me all LLRs that have no test. For each one, suggest a test
+name and a one-line purpose.
+```
+
+```
+HLR-<NNN> is showing as untested in Traceability.md. Walk me
+through what is missing and how to fix it.
+```
+
+```
+Check my test coverage and list every requirement that has a gap.
+```
+
+#### Generating and updating documents
+
+```
+Regenerate all five spec documents from the current Project.xml.
+```
+
+```
+Update the Traceability matrix after I added two new tests.
+```
+
+```
+Preview the HLRs document without writing it to disk.
+```
+
+#### Review and consistency
+
+```
+Review Project.xml for broken traces or ID format problems.
+```
+
+```
+Are there any LLRs that trace to an HLR outside their expected
+section? Flag anything that looks misplaced.
+```
+
+```
+The linter is reporting a warning on HLR-<NNN>. What does it
+mean and how do I fix it?
+```
+
+```
+Trace HLR-<NNN> all the way to its tests and show me the full
+chain.
+```
+
+> **Tip:** The more specific you are, the better the result. Mentioning
+> the exact HLR or LLR ID, the function name, or the test file path
+> helps Copilot locate the right node in `Project.xml` and produce a
+> clean, ready-to-paste edit rather than a generic suggestion.
+
 ## VS Code Extension
 
 When the extension is active, you get the following surfaces. They
@@ -536,7 +654,8 @@ python3 tools/render_doc.py --all
 # Regenerate just one document by name.
 python3 tools/render_doc.py tools/templates/HLRs.md.j2 HLRs --out doc/HLRs.md
 
-# Bootstrap a brand-new project (creates Project.xml, PVD, SAR, VR, SDP).
+# Bootstrap a brand-new project (creates Project.xml, PVD, and the
+# Copilot TraceR skill file at .github/skills/tracer/SKILL.md).
 python3 tools/render_doc.py --init \
     --name "MyProject" --short-name MP --author "Me" \
     --xml doc/Project.xml
@@ -583,6 +702,7 @@ make -C tools lint          # run the linter
 make -C tools validate-xml  # validate against the schema only
 make -C tools test          # run the test suite
 make -C tools ci            # render + lint + validate + test
+make -C tools install       # build, package, and install the extension
 ```
 
 This is what you'd normally wire into a continuous-integration

--- a/tools/User_Manual.md
+++ b/tools/User_Manual.md
@@ -763,25 +763,27 @@ see the [Developer's Guide](Developers_Guide.md).
 
 ## Agents and Prompts
 
-TraceR ships reusable VS Code agent and prompt files under
+When you initialise a project with **Project Spec: Initialise
+Project.xml…**, the extension automatically installs a set of
+reusable agent and prompt files into your workspace under
 `.github/agents/` and `.github/prompts/`. These work with AI
 coding assistants (such as GitHub Copilot) that support agent
 and prompt discovery.
 
-### Agents (`.github/agents/`)
+Existing files are **never overwritten**, so your own
+customisations are always preserved.
+
+### Agents installed into your workspace
 
 Agents are interactive — they ask questions and guide you
 through a task.
 
 | Agent | Purpose |
 | ----- | ------- |
-| **ci.agent.md** | Create and maintain GitHub Actions workflows. Presents a menu of common workflow categories (CI, code quality, releases, PR automation, etc.) and generates the YAML. |
-| **makefile.agent.md** | Create and maintain Makefiles. Prompts for targets, implements them with the self-documenting help hack (`make help` lists all targets). |
-| **TracerDevelop.agent.md** | Project-specific development agent. Expert in the TraceR architecture (Python tools, VS Code extension, schema, sidecar, AI pipeline). Use for implementing features. |
-| **build.agent.md** | Build the VS Code extension (`npm run build`). |
-| **package.agent.md** | Package the extension into a `.vsix` (delegates to build, then runs `vsce package`). |
+| **ci.agent.md** | Create and maintain GitHub Actions workflows. Presents a menu of common workflow categories (CI, code quality, releases, PR automation, etc.) and generates the YAML. Works for any language or framework. |
+| **makefile.agent.md** | Create and maintain Makefiles. Asks what targets you need, implements them with the self-documenting help hack (`make help` lists all targets). Works for any project type. |
 
-### Prompts (`.github/prompts/`)
+### Prompts installed into your workspace
 
 Prompts are automated workflows — they execute a fixed sequence of
 steps with approval gates.
@@ -789,32 +791,60 @@ steps with approval gates.
 | Prompt | Purpose |
 | ------ | ------- |
 | **UpdateDocs.prompt.md** | Scan the current branch's changes and update spec documents (SDD, HLRs, LLRs, Tests in Project.xml; SDP, SAR, User Manual, Developers Guide) to match the work done. |
-| **PR.prompt.md** | Update the SDP status, generate a release-note-quality commit message, commit, push, and open a pull request. |
+| **PR.prompt.md** | Update the SDP status, run static analysis, triage Dependabot alerts, generate a release-note-quality commit message, commit, push, and open a pull request. |
 | **PrepRelease.prompt.md** | Prepare a release: bump VERSION, triage Dependabot alerts (dismiss with justification where possible), update the Vulnerability Report, commit, push, and open a release PR. |
-| **Release.prompt.md** | Create a GitHub Release using the version from VERSION, with auto-generated categorised release notes. |
+| **Release.prompt.md** | Create a GitHub Release using the version from VERSION, with auto-generated categorised release notes. Optionally attaches build artefacts. |
+
+All prompts are generic — they discover project paths dynamically
+and work for any project type (embedded C, Python, TypeScript, etc.)
+that uses TraceR to maintain a `Project.xml`.
 
 ### Using agents and prompts
 
 In VS Code with GitHub Copilot, agents and prompts appear in the
-Chat panel. Type `@` to see available agents, or use the prompt
-picker to select a prompt. They can also be invoked from the
-command palette.
+Chat panel. Use the prompt picker (the attachment icon in the
+Chat input box) to select a prompt and run it. Agents appear when
+you type `@` in the Chat panel.
 
-All prompts are generic — they discover project paths dynamically
-and work in any repository that uses TraceR to maintain a
-`Project.xml`.
+### Retrieving installed files manually
 
-## Appendix A: AI Skill Reference (SKILL.md)
+If you created your project before this feature existed, or need
+to reinstall the files, copy them from the extension bundle:
+
+```
+~/.vscode/extensions/tracer.vscode-project-xml-<version>/
+    dist/github/prompts/   ← copy to .github/prompts/
+    dist/github/agents/    ← copy to .github/agents/
+    media/skills/tracer/   ← copy to .github/skills/tracer/
+```
+
+## Appendix A: AI Scaffolding Reference
 
 When you initialise a new project with **Project Spec: Initialise
-Project.xml…**, the extension automatically copies a
-**SKILL.md** file into `.github/skills/tracer/SKILL.md` in your
-workspace. This file is an AI-agent skill definition — AI coding
-assistants (such as GitHub Copilot) that support skill discovery
-will read it automatically and learn how to work with your
-TraceR project.
+Project.xml…**, the extension installs three categories of AI
+scaffolding into your workspace:
 
-### What the skill file contains
+1. **Skill** (`.github/skills/tracer/SKILL.md`) — passive guidance
+   that AI agents read automatically whenever they work in your
+   project.
+2. **Prompts** (`.github/prompts/`) — automated multi-step
+   workflows for PR submission, release preparation, and spec
+   maintenance.
+3. **Agents** (`.github/agents/`) — interactive task assistants
+   for CI workflow authoring and Makefile maintenance.
+
+All three are described in the [Agents and Prompts](#agents-and-prompts)
+section. The remainder of this appendix covers the SKILL.md in
+depth.
+
+### SKILL.md — TraceR workflow guidance
+
+The **SKILL.md** file at `.github/skills/tracer/SKILL.md` is an
+AI-agent skill definition — AI coding assistants (such as GitHub
+Copilot) that support skill discovery will read it automatically
+and learn how to work with your TraceR project.
+
+### What SKILL.md contains
 
 The SKILL.md teaches AI agents:
 
@@ -837,22 +867,12 @@ The SKILL.md teaches AI agents:
   generated files, forgetting traces, not rendering after edits),
   written so the AI agent avoids them too.
 
-### When to use it
+### How the skill works
 
 You don't need to do anything — the skill file works passively. As
 long as it's at `.github/skills/tracer/SKILL.md`, any AI agent
 that supports VS Code skills will discover it and apply the
 guidance when you ask it to work on your TraceR project.
-
-If you're using a project that was created before this feature
-existed, you can copy the file manually from the extension:
-
-```
-~/.vscode/extensions/tracer.vscode-project-xml-<version>/
-    media/skills/tracer/SKILL.md
-```
-
-…into your workspace at `.github/skills/tracer/SKILL.md`.
 
 ### Customising the skill
 

--- a/tools/render_doc.py
+++ b/tools/render_doc.py
@@ -925,6 +925,7 @@ PVD_TEMPLATE = Path(__file__).resolve().parent / "templates" / "PVD.md.template"
 SAR_TEMPLATE = Path(__file__).resolve().parent / "templates" / "SAR.md.template"
 VR_TEMPLATE = Path(__file__).resolve().parent / "templates" / "VR.md.template"
 SDP_TEMPLATE = Path(__file__).resolve().parent / "templates" / "SDP.md.template"
+TRACER_SKILL_TEMPLATE = Path(__file__).resolve().parent / "templates" / "tracer.skill.md"
 
 # All hand-authored document templates (not Jinja2-rendered from Project.xml)
 AUTHORED_TEMPLATES = {
@@ -1156,10 +1157,10 @@ def init_project(
 
     targets = [xml_path, pvd_path]
     existing = [p for p in targets if p.exists()]
-    if existing and not force:
+    if xml_path.exists() and not force:
         raise ProjectXmlError(
             "refusing to overwrite existing file(s): "
-            + ", ".join(str(p) for p in existing)
+            + str(xml_path)
             + " (pass force=True to overwrite)"
         )
 
@@ -1183,17 +1184,29 @@ def init_project(
 
     # Substitute the obvious header placeholders in the PVD template.
     # Body placeholders (e.g. <Persona 1>, <Capability 1>) are left for
-    # the human author to fill in.
+    # the human author to fill in.  Skip writing if PVD already exists
+    # (preserve any existing hand-authored content).
     pvd_text = pvd_template.read_text()
     pvd_text = pvd_text.replace("<Product Name>", name)
     pvd_text = pvd_text.replace("<short_name>", short_name)
     pvd_text = pvd_text.replace("<YYYY-MM-DD>", today)
     pvd_text = pvd_text.replace("<Your name(s)>", author)
-    pvd_path.write_text(pvd_text)
+    if not pvd_path.exists():
+        pvd_path.write_text(pvd_text)
+
+    # Install the TraceR AI skill file into the project's .github/ directory
+    # so Copilot loads the TraceR working rules for this repository.
+    # The project root is assumed to be two levels above xml_path (i.e.,
+    # <root>/doc/Project.xml → <root>).
+    skill_path = xml_path.resolve().parent.parent / ".github" / "skills" / "tracer" / "SKILL.md"
+    if not skill_path.exists() and TRACER_SKILL_TEMPLATE.exists():
+        skill_path.parent.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text(TRACER_SKILL_TEMPLATE.read_text())
 
     return {
         "xml_path": str(xml_path),
         "pvd_path": str(pvd_path),
+        "skill_path": str(skill_path),
         "existing": [str(p) for p in existing] if force else [],
     }
 

--- a/tools/templates/tracer.skill.md
+++ b/tools/templates/tracer.skill.md
@@ -1,0 +1,127 @@
+---
+name: tracer
+description: "Use when working with this project's specification, requirements, design, tests, or traceability. This project is managed by TraceR — doc/Project.xml is the SINGLE SOURCE OF TRUTH for design, requirements, and verification. USE FOR: reading, editing, creating, generating, updating, or regenerating any spec document — SDD (Software Design Document), HLRs (High-Level Requirements), LLRs (Low-Level Requirements), STP (Software Test Plan), Traceability matrix, or PVD (Product Vision Document); any change to doc/Project.xml or doc/PVD.md; adding, removing, or editing requirements (HLRs or LLRs); adding tests that trace or link to requirements; generating doc/SDD.md, doc/HLRs.md, doc/LLRs.md, doc/STP.md, or doc/Traceability.md; checking, fixing, or understanding test coverage; tracing or linking a requirement to a test; finding untested or uncovered requirements; explaining why a requirement or test is missing from a document; linting or validating the project spec. DO NOT USE FOR: routine source-code changes that do not alter a documented behaviour or requirement."
+---
+
+# TraceR — AI Working Rules
+
+This project is managed by [TraceR](https://github.com/racerxr650r/TraceR).
+`doc/Project.xml` is the **single source of truth** for the project's
+specification, design, and verification artefacts.
+
+## Document Map
+
+| File | How it is maintained | Rule |
+| ---- | -------------------- | ---- |
+| `doc/Project.xml` | **Hand-edited** | The only spec file you change directly |
+| `doc/PVD.md` | **Hand-authored** | Product Vision Document — not generated |
+| `doc/SDD.md` | **Generated** | Never edit — regenerate from `Project.xml` |
+| `doc/HLRs.md` | **Generated** | Never edit — regenerate from `Project.xml` |
+| `doc/LLRs.md` | **Generated** | Never edit — regenerate from `Project.xml` |
+| `doc/STP.md` | **Generated** | Never edit — regenerate from `Project.xml` |
+| `doc/Traceability.md` | **Generated** | Never edit — regenerate from `Project.xml` |
+
+## Hard Rules
+
+1. **Never edit `doc/SDD.md`, `doc/HLRs.md`, `doc/LLRs.md`, `doc/STP.md`,
+   or `doc/Traceability.md` directly.** They are generated from
+   `doc/Project.xml`. Any hand edit is overwritten on the next render.
+
+2. **IDs are stable contracts.** `HLR-NNN` and `LLR-XXX-NN` identifiers
+   may never be renumbered or reused once allocated. Always allocate the
+   next free number when adding a new item.
+
+3. **Every `<hlr>` must carry at least one `<traces target="SDD" ref="N.N">`.
+   Every `<llr>` must carry at least one `<traces target="HLR" ref="HLR-NNN">`.
+   Every `<test>` must carry at least one `<traces target="LLR" ref="LLR-XXX-NN">`
+   or `<traces target="HLR" ref="HLR-NNN">`.** Missing traces produce
+   coverage-gap rows in `doc/Traceability.md` and linter warnings.
+
+4. **Wrap special characters in CDATA.** Any `<text>`, `<purpose>`,
+   `<intro>`, or other body element whose content contains backticks,
+   angle brackets (`<`, `>`), ampersands (`&`), or Markdown link syntax
+   (`[text](url)`) must be wrapped in `<![CDATA[...]]>`. Bare `<` or `&`
+   silently corrupt the file on the next parse.
+
+5. **Headings and section numbers belong in templates, not in data.**
+   Do not put `##` headings, section numbers, or "Document Overview"
+   prose inside `<sdd>` or `<stp>` payloads — the renderer adds all
+   document scaffolding.
+
+6. **Anchors are owned by the templates.** The generated HLRs.md,
+   LLRs.md, and STP.md emit `<a id="...">` for every requirement and
+   test name so Traceability.md can link to them. Do not add or remove
+   these anchors manually.
+
+## Traceability Chain
+
+```
+SDD sections  ←── HLR  (traces target="SDD" ref="N.N")
+HLR items     ←── LLR  (traces target="HLR" ref="HLR-NNN")
+LLR items     ←── Test (traces target="LLR" ref="LLR-XXX-NN")
+```
+
+Coverage gaps — items with no downstream trace — appear as warning rows
+in `doc/Traceability.md` and in the VS Code Problems panel.
+
+## Decision Flow
+
+| Intent | Action |
+| ------ | ------ |
+| Update a section of the SDD | Edit the matching node inside `<sdd>` in `Project.xml`, then render `SDD`. |
+| Add an HLR | Append `<hlr id="HLR-NNN" name="...">` in the correct `<section>`; add `<traces target="SDD" ref="N.N">` for every SDD section it implements. Render `HLRs` and `Traceability`. |
+| Add an LLR | Append `<llr id="LLR-XXX-NN">` in the correct `<function>`; add `<traces target="HLR" ref="HLR-NNN">` for every HLR it implements. Render `LLRs` and `Traceability`. |
+| Add a test | Add the test function in source with a comment citing the LLR(s)/HLR(s). Add a matching `<test name="...">` with `<purpose>` and `<traces>` inside the correct `<tests>/<file>` node. Render `STP` and `Traceability`. |
+| Close a coverage gap (requirement has no test) | Check whether a downstream LLR traces to the requirement and whether that LLR has a test tracing to it. Add the missing trace link or create the missing test. |
+| Wrong ID format (linter warning) | Use the Quick Fix lightbulb in VS Code, or manually allocate the next free ID — never reuse an existing number. |
+| Broken trace (linter error) | The `ref` attribute points to an ID that does not exist. Use the Quick Fix lightbulb to pick a valid replacement, or correct it by hand. |
+
+## Rendering
+
+After editing `doc/Project.xml`, regenerate the affected documents.
+
+**Via VS Code (preferred):**
+
+- **Command Palette** (`Ctrl+Shift+P`) → **Project Spec: Render All Documents** —
+  regenerates all five spec documents at once.
+- **Project Spec: Render & Preview** — renders one document in memory for
+  review without writing files to disk.
+
+**Via the linter:**
+
+The linter re-checks `Project.xml` on every save. Run it manually via
+**Project Spec: Run Linter** in the Command Palette, or look at the
+**Problems** panel (`Ctrl+Shift+M`). Common problems include:
+
+- A trace pointing at a requirement ID that does not exist.
+- An ID that does not follow the required pattern (`HLR-NNN` or `LLR-XXX-NN`).
+- A requirement that has no downstream test.
+
+## Product Vision Document (PVD)
+
+`doc/PVD.md` is the **hand-authored** Product Vision Document. It defines
+*why* the product exists, *who* it is for, and *how success is measured*.
+It is **not** generated from `Project.xml` — never overwrite it from a
+template.
+
+**AI role:** the developer is the author; the AI is the ghostwriter.
+
+When asked to work on the PVD:
+
+1. Read `doc/PVD.md` first to see what sections exist and how complete
+   each one is.
+2. Identify thin or missing sections (placeholders, one-line summaries
+   where a paragraph is expected, TODO markers, single-item lists).
+3. Ask the developer targeted questions to elicit the missing content
+   before drafting it. Prefer a small number of specific, answerable
+   questions over open-ended prompts.
+4. Draft the content once answered. Match the existing tone, heading
+   depth, and table style of the document.
+5. Do not invent product direction — if a question is genuinely open
+   (scope, target users, success metrics, roadmap), ask rather than guess.
+
+Expected PVD sections (in roughly this order): Vision Statement,
+Problem Statement, Target Users (with personas), Value Proposition,
+Product Principles, Scope (in / out / non-goals), Success Metrics,
+Roadmap Themes, Relationship to the spec stack (PVD → HLRs → LLRs →
+SDD → STP → Traceability).

--- a/tools/vscode-project-xml/package-lock.json
+++ b/tools/vscode-project-xml/package-lock.json
@@ -201,17 +201,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.4.tgz",
-      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+      "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.6.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+      "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6319,10 +6329,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -7420,10 +7431,11 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -7530,10 +7542,11 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -7859,15 +7872,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -8045,10 +8049,11 @@
       }
     },
     "node_modules/vscode-extension-tester/node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -8166,10 +8171,11 @@
       }
     },
     "node_modules/vscode-extension-tester/node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -8421,10 +8427,11 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/tools/vscode-project-xml/scripts/prepackage.js
+++ b/tools/vscode-project-xml/scripts/prepackage.js
@@ -55,6 +55,22 @@ const REPO_ROOT = path.resolve(TOOLS_SRC, '..');                 // project root
 const SCREENSHOTS_SRC = path.join(REPO_ROOT, 'images', 'screenshots');
 const SCREENSHOTS_DST_REL = path.join('..', 'images', 'screenshots');  // relative to DIST
 
+// Generic prompts and agents installable into any project that uses TraceR.
+// TraceR-internal agents (TracerDevelop, build, package) are intentionally
+// excluded — they are only meaningful inside this repository.
+const GITHUB_SRC = path.join(REPO_ROOT, '.github');
+const DIST_GITHUB = path.join(EXT_ROOT, 'dist', 'github');
+const GENERIC_PROMPTS = [
+    'PR.prompt.md',
+    'PrepRelease.prompt.md',
+    'Release.prompt.md',
+    'UpdateDocs.prompt.md',
+];
+const GENERIC_AGENTS = [
+    'ci.agent.md',
+    'makefile.agent.md',
+];
+
 /** Recursively remove a directory if it exists. */
 function rmrf(target) {
     if (!fs.existsSync(target)) {
@@ -179,6 +195,29 @@ function main() {
     // Install third-party Python packages into dist/python/ so the sidecar
     // starts successfully in any workspace, not just the TraceR dev env.
     installPythonDeps(DIST);
+
+    // Copy generic prompts and agents into dist/github/ so initProject can
+    // install them into new workspaces without needing the source repo.
+    const distPrompts = path.join(DIST_GITHUB, 'prompts');
+    const distAgents  = path.join(DIST_GITHUB, 'agents');
+    fs.mkdirSync(distPrompts, { recursive: true });
+    fs.mkdirSync(distAgents,  { recursive: true });
+    for (const name of GENERIC_PROMPTS) {
+        const src = path.join(GITHUB_SRC, 'prompts', name);
+        if (fs.existsSync(src)) {
+            fs.copyFileSync(src, path.join(distPrompts, name));
+        }
+    }
+    for (const name of GENERIC_AGENTS) {
+        const src = path.join(GITHUB_SRC, 'agents', name);
+        if (fs.existsSync(src)) {
+            fs.copyFileSync(src, path.join(distAgents, name));
+        }
+    }
+    process.stdout.write(
+        `prepackage: copied ${GENERIC_PROMPTS.length} prompts and ` +
+        `${GENERIC_AGENTS.length} agents into dist/github/\n`,
+    );
 
     const version = readSchemaVersion(path.join(DIST, 'project.xsd'));
     fs.writeFileSync(path.join(DIST, '.bundle_version'), `${version}\n`, 'utf8');

--- a/tools/vscode-project-xml/scripts/prepackage.js
+++ b/tools/vscode-project-xml/scripts/prepackage.js
@@ -21,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const HERE = __dirname;                                          // tools/vscode-project-xml/scripts
 const EXT_ROOT = path.resolve(HERE, '..');                       // tools/vscode-project-xml
@@ -95,6 +96,50 @@ function readSchemaVersion(xsdPath) {
     return match[1];
 }
 
+/**
+ * Install required Python packages into `dist/python/` so the sidecar works
+ * without any additional setup in the user's workspace.  Packages land in the
+ * same directory as `project_io.py`, which Python adds to `sys.path` when it
+ * runs the script, so they are found automatically.
+ */
+function installPythonDeps(dist) {
+    // Prefer the workspace venv Python if present (matches the TraceR dev env).
+    const candidates = [];
+    const venvPython = path.resolve(REPO_ROOT, '.venv', 'bin', 'python');
+    if (fs.existsSync(venvPython)) {
+        candidates.push(venvPython);
+    }
+    candidates.push('python3', 'python');
+
+    const packages = ['defusedxml', 'jinja2', 'lxml'];
+
+    for (const py of candidates) {
+        const result = spawnSync(py, [
+            '-m', 'pip', 'install', '--quiet',
+            '--target', dist,
+            ...packages,
+        ], { encoding: 'utf8' });
+
+        if (result.error) {
+            if (result.error.code === 'ENOENT') {
+                continue;  // this candidate doesn't exist; try the next one
+            }
+            throw new Error(`prepackage: pip install error: ${result.error.message}`);
+        }
+        if (result.status !== 0) {
+            throw new Error(
+                `prepackage: pip install failed (status=${result.status}):\n${result.stderr}`,
+            );
+        }
+        process.stdout.write(`prepackage: installed Python deps via ${py}\n`);
+        return;
+    }
+    throw new Error(
+        'prepackage: could not find python3 or python to install dependencies. ' +
+        'Ensure Python is on your PATH.',
+    );
+}
+
 function main() {
     rmrf(DIST);
     fs.mkdirSync(DIST, { recursive: true });
@@ -130,6 +175,10 @@ function main() {
         const dst = path.resolve(DIST, SCREENSHOTS_DST_REL);
         copyDir(SCREENSHOTS_SRC, dst);
     }
+
+    // Install third-party Python packages into dist/python/ so the sidecar
+    // starts successfully in any workspace, not just the TraceR dev env.
+    installPythonDeps(DIST);
 
     const version = readSchemaVersion(path.join(DIST, 'project.xsd'));
     fs.writeFileSync(path.join(DIST, '.bundle_version'), `${version}\n`, 'utf8');

--- a/tools/vscode-project-xml/src/commands/initProject.ts
+++ b/tools/vscode-project-xml/src/commands/initProject.ts
@@ -66,10 +66,18 @@ export async function initProject(
         return undefined;
     }
 
+    const xmlRel = getConfig().get<string>('xmlPath') ?? 'doc/Project.xml';
+    const xmlAbs = path.isAbsolute(xmlRel)
+        ? xmlRel
+        : path.join(folder.uri.fsPath, xmlRel);
+    const pvdAbs = path.join(path.dirname(xmlAbs), 'PVD.md');
+
     const params = {
         name: name.trim(),
         short_name: shortName.trim(),
         author: author.trim() || 'TBD',
+        xml_path: xmlAbs,
+        pvd_path: pvdAbs,
     };
 
     let result;

--- a/tools/vscode-project-xml/src/commands/initProject.ts
+++ b/tools/vscode-project-xml/src/commands/initProject.ts
@@ -150,6 +150,9 @@ export async function initProject(
     // Copy the bundled TraceR SKILL.md into .github/skills/tracer/
     // so AI agents in the new workspace automatically pick up the
     // TraceR workflow guidance.
+    //
+    // Also install the generic prompts and agents bundled in dist/github/
+    // so the PR, release, and Makefile workflows are ready to use.
     const ctx = getExtensionContext();
     if (ctx) {
         const skillSrc = path.join(ctx.extensionPath, 'media', 'skills', 'tracer', 'SKILL.md');
@@ -160,6 +163,27 @@ export async function initProject(
                 fs.copyFileSync(skillSrc, skillDst);
             } catch {
                 // Non-fatal — the skill file is a convenience.
+            }
+        }
+
+        // Install generic prompts (PR, PrepRelease, Release, UpdateDocs) and
+        // agents (ci, makefile) from the bundle into the new workspace.
+        // Existing files are never overwritten so user customisations are safe.
+        const distGithub = path.join(ctx.extensionPath, 'dist', 'github');
+        for (const [subdir] of [['prompts'], ['agents']] as [string][]) {
+            const srcDir = path.join(distGithub, subdir);
+            const dstDir = path.join(folder.uri.fsPath, '.github', subdir);
+            if (!fs.existsSync(srcDir)) { continue; }
+            try {
+                fs.mkdirSync(dstDir, { recursive: true });
+                for (const name of fs.readdirSync(srcDir)) {
+                    const dst = path.join(dstDir, name);
+                    if (!fs.existsSync(dst)) {
+                        fs.copyFileSync(path.join(srcDir, name), dst);
+                    }
+                }
+            } catch {
+                // Non-fatal — prompts and agents are conveniences.
             }
         }
     }

--- a/tools/vscode-project-xml/src/sidecar.ts
+++ b/tools/vscode-project-xml/src/sidecar.ts
@@ -188,7 +188,7 @@ export class ProjectIoClient implements vscode.Disposable {
     }
 
     private ensureStarted(): ChildProcessWithoutNullStreams {
-        if (this.proc && !this.proc.killed) {
+        if (this.proc && !this.proc.killed && !this.proc.stdin.destroyed) {
             return this.proc;
         }
         if (this.startError) {
@@ -201,6 +201,19 @@ export class ProjectIoClient implements vscode.Disposable {
             this.startError = err;
             throw err;
         }
+        // Guard against the fallback path that getToolsDir() may return
+        // even when neither the workspace tools/ nor the bundled dist/python
+        // exists.  Node.js reports "spawn <python> ENOENT" when the cwd is
+        // missing, which is deeply confusing.  Surface a clear message and
+        // do NOT cache it (restart() clears startError; the script may
+        // appear after the user scaffolds or reinstalls).
+        if (!fs.existsSync(script)) {
+            throw new Error(
+                `project_io.py not found at "${script}". ` +
+                'Re-install the extension or run ' +
+                '"Project Spec: Scaffold tools/ into workspace…" to copy the toolchain.',
+            );
+        }
         const python = pickPython();
         this.outputChannel.appendLine(
             `[sidecar] spawn: ${python} ${script} (cwd=${path.dirname(script)})`,
@@ -212,7 +225,9 @@ export class ProjectIoClient implements vscode.Disposable {
         proc.stdout.setEncoding('utf8');
         proc.stderr.setEncoding('utf8');
         proc.stdout.on('data', (chunk: string) => this.onStdout(chunk));
+        let stderrBuf = '';
         proc.stderr.on('data', (chunk: string) => {
+            stderrBuf += chunk;
             this.outputChannel.append(`[sidecar:stderr] ${chunk}`);
         });
         proc.on('error', (err) => {
@@ -220,15 +235,17 @@ export class ProjectIoClient implements vscode.Disposable {
                 `[sidecar] spawn error: ${err.message}`,
             );
             this.failAll(err);
+            this.proc = undefined;
         });
         proc.on('exit', (code, signal) => {
             this.outputChannel.appendLine(
                 `[sidecar] exited code=${code} signal=${signal ?? ''}`,
             );
-            const err = new Error(
-                `project_io.py exited (code=${code}, signal=${signal ?? ''})`,
-            );
-            this.failAll(err);
+            const detail = stderrBuf.trim();
+            const msg = detail
+                ? `project_io.py exited (code=${code}):\n${detail}`
+                : `project_io.py exited (code=${code}, signal=${signal ?? ''})`;
+            this.failAll(new Error(msg));
             this.proc = undefined;
         });
         this.proc = proc;
@@ -338,7 +355,23 @@ function pickPython(): string {
             return venvPy;
         }
     }
-    // 4. Bare system fallback.
+    // 4. Search PATH for python3 then python (or python then python3 on
+    //    Windows) so we find the interpreter even when only one name is
+    //    registered, and avoid a spurious ENOENT on spawn.
+    const candidates = process.platform === 'win32'
+        ? ['python', 'python3']
+        : ['python3', 'python'];
+    const pathEnv = process.env.PATH ?? '';
+    for (const name of candidates) {
+        for (const dir of pathEnv.split(path.delimiter)) {
+            if (!dir) { continue; }
+            const candidate = path.join(dir, name);
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+        }
+    }
+    // 5. Last-resort bare name — let the OS surface a clear ENOENT.
     return process.platform === 'win32' ? 'python' : 'python3';
 }
 


### PR DESCRIPTION
## Summary

- `init_project` preserves existing `PVD.md` on re-init (asymmetric overwrite guard); only `Project.xml` is replaced (LLR-INI-05)
- `init_project` installs `.github/skills/tracer/SKILL.md` from bundled template and returns `skill_path` in JSON-RPC result (LLR-INI-05)
- `prepackage.js` vendors `defusedxml`, `jinja2`, and `lxml` into `dist/python/` so the shipped `.vsix` is fully self-contained without a system Python environment (LLR-PKG-12)
- Sidecar `ensureStarted()` guards against writing to a destroyed `stdin`; stderr buffered and included in exit error messages
- `pickPython()` searches all PATH entries for `python3`/`python` before falling back to the bare name
- New LLRs LLR-INI-05 and LLR-PKG-12 added to `doc/Project.xml`; HLR-009 and HLR-060 updated
- 5 new regression tests; all 56 Python tests pass; lint 0 errors
- All 5 generated spec docs regenerated (SDD, HLRs, LLRs, STP, Traceability)
- `User_Manual.md` updated with "Using Copilot Chat" section
- `project-xml` agent SKILL.md updated with verification-environment policy

## Checklist

- [x] SDP updated (Phase 15 added)
- [x] Static analysis run (`make -C tools analyze` — 2026-06-02)
- [x] SAR updated (§6.1/6.2/6.3 counts, §7 npm audit, §11 residual risk)
- [x] Dependabot triaged (alerts #16, #17, #18 dismissed as `not_used`)
- [x] VR updated (§2 summary, §5 accepted risks, §6 dismissed)
- [x] Tests pass (56 Python tests, 0 errors)
- [x] Lint clean (0 errors, 49 warnings — all pre-existing)

Closes #50